### PR TITLE
Fix security alerts and refresh calendar config UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,6 +211,7 @@ scripts/AGENTS.md
 
 # Local assistant artifacts
 .sisyphus/
+.playwright-cli/
 
 # Local dev runtime data
 .local-dev-data/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Frontend
+
+#### Changed
+
+- **Calendar configure tooltip refresh** - Reworked the weather availability hint into a floating tooltip that follows the pointer, stays clear of the desktop sidebar, and remains keyboard-accessible by using `aria-disabled` state instead of relying on native disabled-button hover behavior
+- **Credits wording and layout sync** - Aligned homepage and desktop credits labels with the mobile drawer wording, expanded provider attribution rows, and standardized entries such as `Jolpica-F1 API`, `Weather-icons`, analytics, hosting, and device sources
+
+### Backend
+
+#### Changed
+
+- **Public redirect hardening** - Switched the remaining public-page language redirects on home, configure, privacy, changelog, API docs, and stats routes to the validated `_redirect_path()` helper so canonical redirects keep only approved on-site targets and preserve the intended query handling
+
+### Security
+
+#### Fixed
+
+- **Dependency vulnerability updates** - Bumped `pygments` in `uv.lock` and `picomatch` in `package-lock.json` to patched versions to clear the open GitHub security alerts on the release branch
+
+### Development
+
+#### Changed
+
+- **Local artifact ignore rules** - Added `.playwright-cli/` to `.gitignore` so Playwright CLI snapshots and console captures do not get committed with future UI review iterations
+
 ## [1.2.18] - 2026-03-30
 
 ### Frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.19] - 2026-03-31
+
 ### Frontend
 
 #### Changed

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -199,9 +199,7 @@ async def configure_screen_slash_redirect(request: Request, screen_type: str):
 async def configure_screen(request: Request, screen_type: str, lang: str = Query(default=None)):
     """Configure page (English default)."""
     if lang in VALID_LANGUAGES and lang != "en":
-        return _redirect_path(
-            request, f"/{lang}/configure/{screen_type}", preserve_query=False
-        )
+        return _redirect_path(request, f"/{lang}/configure/{screen_type}", preserve_query=False)
     if lang is not None and lang not in VALID_LANGUAGES:
         return _redirect_path(request, f"/configure/{screen_type}", preserve_query=False)
     if request.method == "HEAD":
@@ -449,9 +447,7 @@ async def api_docs_html_lang(request: Request, lang_prefix: str, lang: str = Que
     if lang_prefix == "en":
         return _redirect_path(request, "/api/docs/html", preserve_query=False)
     if lang is not None:
-        return _redirect_path(
-            request, f"/{lang_prefix}/api/docs/html", preserve_query=False
-        )
+        return _redirect_path(request, f"/{lang_prefix}/api/docs/html", preserve_query=False)
     if request.method == "HEAD":
         return _head_ok()
     return await _api_docs_handler(request, lang_prefix)

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -134,9 +134,9 @@ async def _home_handler(request: Request, ui_lang: str) -> HTMLResponse:
 async def root(request: Request, lang: str = Query(default=None)):
     """Home page (English default)."""
     if lang in VALID_LANGUAGES and lang != "en":
-        return RedirectResponse(url=f"/{lang}/", status_code=301)
+        return _redirect_path(request, f"/{lang}/", preserve_query=False)
     if lang is not None and lang not in VALID_LANGUAGES:
-        return RedirectResponse(url="/", status_code=301)
+        return _redirect_path(request, "/", preserve_query=False)
     if request.method == "HEAD":
         return _head_ok()
     return await _home_handler(request, "en")
@@ -148,9 +148,9 @@ async def root_lang(request: Request, lang_prefix: str, lang: str = Query(defaul
     if lang_prefix not in VALID_LANGUAGES:
         raise HTTPException(status_code=404, detail="Not found")
     if lang_prefix == "en":
-        return RedirectResponse(url="/", status_code=301)
+        return _redirect_path(request, "/", preserve_query=False)
     if lang is not None:
-        return RedirectResponse(url=f"/{lang_prefix}/", status_code=301)
+        return _redirect_path(request, f"/{lang_prefix}/", preserve_query=False)
     if request.method == "HEAD":
         return _head_ok()
     return await _home_handler(request, lang_prefix)
@@ -199,9 +199,11 @@ async def configure_screen_slash_redirect(request: Request, screen_type: str):
 async def configure_screen(request: Request, screen_type: str, lang: str = Query(default=None)):
     """Configure page (English default)."""
     if lang in VALID_LANGUAGES and lang != "en":
-        return RedirectResponse(url=f"/{lang}/configure/{screen_type}", status_code=301)
+        return _redirect_path(
+            request, f"/{lang}/configure/{screen_type}", preserve_query=False
+        )
     if lang is not None and lang not in VALID_LANGUAGES:
-        return RedirectResponse(url=f"/configure/{screen_type}", status_code=301)
+        return _redirect_path(request, f"/configure/{screen_type}", preserve_query=False)
     if request.method == "HEAD":
         return _head_ok()
     return await _configure_handler(request, screen_type, "en")
@@ -237,9 +239,11 @@ async def configure_screen_lang(
     if lang_prefix not in VALID_LANGUAGES:
         raise HTTPException(status_code=404, detail="Not found")
     if lang_prefix == "en":
-        return RedirectResponse(url=f"/configure/{screen_type}", status_code=301)
+        return _redirect_path(request, f"/configure/{screen_type}", preserve_query=False)
     if lang is not None:
-        return RedirectResponse(url=f"/{lang_prefix}/configure/{screen_type}", status_code=301)
+        return _redirect_path(
+            request, f"/{lang_prefix}/configure/{screen_type}", preserve_query=False
+        )
     if request.method == "HEAD":
         return _head_ok()
     return await _configure_handler(request, screen_type, lang_prefix)
@@ -270,9 +274,9 @@ async def _privacy_handler(request: Request, ui_lang: str) -> HTMLResponse:
 async def privacy(request: Request, lang: str = Query(default=None)):
     """Privacy page (English default)."""
     if lang in VALID_LANGUAGES and lang != "en":
-        return RedirectResponse(url=f"/{lang}/privacy", status_code=301)
+        return _redirect_path(request, f"/{lang}/privacy", preserve_query=False)
     if lang is not None and lang not in VALID_LANGUAGES:
-        return RedirectResponse(url="/privacy", status_code=301)
+        return _redirect_path(request, "/privacy", preserve_query=False)
     if request.method == "HEAD":
         return _head_ok()
     return await _privacy_handler(request, "en")
@@ -292,9 +296,9 @@ async def privacy_lang(request: Request, lang_prefix: str, lang: str = Query(def
     if lang_prefix not in VALID_LANGUAGES:
         raise HTTPException(status_code=404, detail="Not found")
     if lang_prefix == "en":
-        return RedirectResponse(url="/privacy", status_code=301)
+        return _redirect_path(request, "/privacy", preserve_query=False)
     if lang is not None:
-        return RedirectResponse(url=f"/{lang_prefix}/privacy", status_code=301)
+        return _redirect_path(request, f"/{lang_prefix}/privacy", preserve_query=False)
     if request.method == "HEAD":
         return _head_ok()
     return await _privacy_handler(request, lang_prefix)
@@ -354,9 +358,9 @@ async def _changelog_handler(request: Request, ui_lang: str) -> HTMLResponse:
 async def changelog(request: Request, lang: str = Query(default=None)):
     """Changelog page (English default)."""
     if lang in VALID_LANGUAGES and lang != "en":
-        return RedirectResponse(url=f"/{lang}/changelog", status_code=301)
+        return _redirect_path(request, f"/{lang}/changelog", preserve_query=False)
     if lang is not None and lang not in VALID_LANGUAGES:
-        return RedirectResponse(url="/changelog", status_code=301)
+        return _redirect_path(request, "/changelog", preserve_query=False)
     if request.method == "HEAD":
         return _head_ok()
     return await _changelog_handler(request, "en")
@@ -376,9 +380,9 @@ async def changelog_lang(request: Request, lang_prefix: str, lang: str = Query(d
     if lang_prefix not in VALID_LANGUAGES:
         raise HTTPException(status_code=404, detail="Not found")
     if lang_prefix == "en":
-        return RedirectResponse(url="/changelog", status_code=301)
+        return _redirect_path(request, "/changelog", preserve_query=False)
     if lang is not None:
-        return RedirectResponse(url=f"/{lang_prefix}/changelog", status_code=301)
+        return _redirect_path(request, f"/{lang_prefix}/changelog", preserve_query=False)
     if request.method == "HEAD":
         return _head_ok()
     return await _changelog_handler(request, lang_prefix)
@@ -419,9 +423,9 @@ async def _api_docs_handler(request: Request, ui_lang: str) -> HTMLResponse:
 async def api_docs_html(request: Request, lang: str = Query(default=None)):
     """API docs page (English default)."""
     if lang in VALID_LANGUAGES and lang != "en":
-        return RedirectResponse(url=f"/{lang}/api/docs/html", status_code=301)
+        return _redirect_path(request, f"/{lang}/api/docs/html", preserve_query=False)
     if lang is not None and lang not in VALID_LANGUAGES:
-        return RedirectResponse(url="/api/docs/html", status_code=301)
+        return _redirect_path(request, "/api/docs/html", preserve_query=False)
     if request.method == "HEAD":
         return _head_ok()
     return await _api_docs_handler(request, "en")
@@ -443,9 +447,11 @@ async def api_docs_html_lang(request: Request, lang_prefix: str, lang: str = Que
     if lang_prefix not in VALID_LANGUAGES:
         raise HTTPException(status_code=404, detail="Not found")
     if lang_prefix == "en":
-        return RedirectResponse(url="/api/docs/html", status_code=301)
+        return _redirect_path(request, "/api/docs/html", preserve_query=False)
     if lang is not None:
-        return RedirectResponse(url=f"/{lang_prefix}/api/docs/html", status_code=301)
+        return _redirect_path(
+            request, f"/{lang_prefix}/api/docs/html", preserve_query=False
+        )
     if request.method == "HEAD":
         return _head_ok()
     return await _api_docs_handler(request, lang_prefix)
@@ -513,12 +519,12 @@ async def stats_dashboard(
         redirect_url = f"/{lang}/stats"
         if time_range != "24h":
             redirect_url += f"?range={time_range}"
-        return RedirectResponse(url=redirect_url, status_code=301)
+        return _redirect_path(request, redirect_url, preserve_query=False)
     if lang is not None and lang not in VALID_LANGUAGES:
         redirect_url = "/stats"
         if time_range != "24h":
             redirect_url += f"?range={time_range}"
-        return RedirectResponse(url=redirect_url, status_code=301)
+        return _redirect_path(request, redirect_url, preserve_query=False)
     if request.method == "HEAD":
         return _head_ok()
     return await _stats_handler(request, time_range, "en")
@@ -544,12 +550,12 @@ async def stats_dashboard_lang(
         redirect_url = "/stats"
         if time_range != "24h":
             redirect_url += f"?range={time_range}"
-        return RedirectResponse(url=redirect_url, status_code=301)
+        return _redirect_path(request, redirect_url, preserve_query=False)
     if lang is not None:
         redirect_url = f"/{lang_prefix}/stats"
         if time_range != "24h":
             redirect_url += f"?range={time_range}"
-        return RedirectResponse(url=redirect_url, status_code=301)
+        return _redirect_path(request, redirect_url, preserve_query=False)
     if request.method == "HEAD":
         return _head_ok()
     return await _stats_handler(request, time_range, lang_prefix)

--- a/app/templates/components/credits_dropdown.html
+++ b/app/templates/components/credits_dropdown.html
@@ -13,13 +13,81 @@
   >
     <div class="p-3 text-xs normal-case tracking-normal font-normal space-y-2">
       <div>
-        <span class="text-gray-500">Inspired by</span>
+        <span class="text-gray-500">Inspiration:</span>
         <a
           href="https://x.com/foxeelab/status/1761498129268981856"
           target="_blank"
           rel="noopener noreferrer"
           class="text-racing-red hover:underline ml-1"
           >FoxeeLab</a
+        >
+      </div>
+      <div>
+        <span class="text-gray-500">Race data:</span>
+        <a
+          href="https://github.com/jolpica/jolpica-f1"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="hover:text-racing-red ml-1"
+          >Jolpica-F1 API</a
+        >
+      </div>
+      <div>
+        <span class="text-gray-500">Weather:</span>
+        <a
+          href="https://open-meteo.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="hover:text-racing-red ml-1"
+          >Open-Meteo</a
+        >
+      </div>
+      <div>
+        <span class="text-gray-500">Icons:</span>
+        <a
+          href="https://github.com/erikflowers/weather-icons"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="hover:text-racing-red ml-1"
+          >Weather-icons</a
+        >
+      </div>
+      <div>
+        <span class="text-gray-500">Flags:</span>
+        <a
+          href="https://flagcdn.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="hover:text-racing-red ml-1"
+          >Flagcdn</a
+        >
+      </div>
+      <div>
+        <span class="text-gray-500">Platform:</span>
+        <a
+          href="https://zivyobraz.eu"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="hover:text-racing-red ml-1"
+          >Živýobraz.eu</a
+        >
+      </div>
+      <div>
+        <span class="text-gray-500">Devices:</span>
+        <a
+          href="https://www.laskakit.cz/laskakit-live-7-5-e-paper-stavebnice-s-wifi-pro---zivy-obraz-/"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="hover:text-racing-red ml-1"
+          >LaskaKit</a
+        >
+        &amp;
+        <a
+          href="https://pajenicko.cz/sverio-paperboard-ctyrbarevny-7.5-gdem075f52-s-cernym-rameckem"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="hover:text-racing-red"
+          >SVERIO</a
         >
       </div>
       <div>
@@ -41,82 +109,24 @@
         >
       </div>
       <div>
-        <span class="text-gray-500">Devices:</span>
+        <span class="text-gray-500">Analytics:</span>
         <a
-          href="https://www.laskakit.cz/laskakit-live-7-5-e-paper-stavebnice-s-wifi-pro---zivy-obraz-/"
+          href="https://umami.is"
           target="_blank"
           rel="noopener noreferrer"
           class="hover:text-racing-red ml-1"
-          >LaskaKit</a
-        >
-        &
-        <a
-          href="https://pajenicko.cz/sverio-paperboard-ctyrbarevny-7.5-gdem075f52-s-cernym-rameckem"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="hover:text-racing-red"
-          >SVERIO</a
+          >Umami</a
         >
       </div>
       <div>
-        <span class="text-gray-500">Weather data:</span>
+        <span class="text-gray-500">Errors:</span>
         <a
-          href="https://open-meteo.com"
+          href="https://glitchtip.com"
           target="_blank"
           rel="noopener noreferrer"
           class="hover:text-racing-red ml-1"
-          >Open-Meteo</a
+          >GlitchTip</a
         >
-      </div>
-      <div>
-        <span class="text-gray-500">Icons:</span>
-        <a
-          href="https://github.com/erikflowers/weather-icons"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="hover:text-racing-red ml-1"
-          >Icons</a
-        >
-      </div>
-      <div class="pt-2 border-t border-gray-200">
-        <span class="text-gray-500 block mb-1">Powered by:</span>
-        <div class="flex flex-wrap gap-x-2 gap-y-1">
-          <a
-            href="https://github.com/jolpica/jolpica-f1"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="hover:text-racing-red"
-            >Jolpica API</a
-          >
-          <a
-            href="https://zivyobraz.eu"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="hover:text-racing-red"
-            >Živýobraz.eu</a
-          >
-          <a
-            href="https://umami.is"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="hover:text-racing-red"
-            >Umami</a
-          >
-          <a
-            href="https://glitchtip.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="hover:text-racing-red"
-            >GlitchTip</a
-          >
-          <a
-            href="https://flagcdn.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="hover:text-racing-red"
-            >Flagcdn</a
-          >
-        </div>
       </div>
     </div>
   </div>

--- a/app/templates/configure.html
+++ b/app/templates/configure.html
@@ -415,8 +415,7 @@ block content %}
 </div>
 <div
   id="weatherHoverTooltip"
-  class="pointer-events-none fixed z-[100] hidden max-w-44 border-2 border-black bg-black px-2 py-1 text-[10px] font-normal normal-case leading-tight text-white shadow-neo-sm"
-  style="z-index: 9999"
+  class="pointer-events-none fixed z-[9999] hidden max-w-44 border-2 border-black bg-black px-2 py-1 text-[10px] font-normal normal-case leading-tight text-white shadow-neo-sm"
 ></div>
 {% endblock %} {% block scripts %}
 <script>
@@ -844,9 +843,13 @@ block content %}
     tooltip.style.top = `${top}px`;
   }
 
+  function isWeatherTooltipDisabledState(trigger) {
+    return trigger?.getAttribute("aria-disabled") === "true";
+  }
+
   function showWeatherHoverTooltip(event) {
     const tooltip = document.getElementById("weatherHoverTooltip");
-    if (!tooltip || !event.currentTarget?.disabled) return;
+    if (!tooltip || !isWeatherTooltipDisabledState(event.currentTarget)) return;
 
     tooltip.textContent = uiText.weatherTooltipText;
     tooltip.classList.remove("hidden");
@@ -867,7 +870,7 @@ block content %}
   }
 
   function showWeatherHoverTooltipFromFocus(event) {
-    if (!event.currentTarget?.disabled) return;
+    if (!isWeatherTooltipDisabledState(event.currentTarget)) return;
 
     const rect = event.currentTarget.getBoundingClientRect();
     showWeatherHoverTooltip({
@@ -1618,7 +1621,14 @@ block content %}
   }
 
   function setWeatherType(type) {
-    if (type === "race_day" && !isRaceDayWeatherAvailable()) {
+    const raceDayBtn = document.getElementById("weatherRaceDayBtn");
+    const raceDayBtnMobile = document.getElementById("weatherRaceDayBtnMobile");
+    const raceDayUnavailable =
+      type === "race_day" &&
+      (isWeatherTooltipDisabledState(raceDayBtn) ||
+        isWeatherTooltipDisabledState(raceDayBtnMobile));
+
+    if (raceDayUnavailable) {
       return;
     }
 
@@ -1701,7 +1711,6 @@ block content %}
     raceDayBtns.forEach((btn) => {
       if (!btn) return;
       if (isRaceDayAvailable) {
-        btn.disabled = false;
         btn.setAttribute("aria-disabled", "false");
         btn.classList.remove(
           "opacity-50",
@@ -1712,7 +1721,6 @@ block content %}
         );
         btn.classList.add("border-black", "hover:bg-black", "hover:text-white");
       } else {
-        btn.disabled = true;
         btn.setAttribute("aria-disabled", "true");
         btn.classList.remove(
           "bg-racing-red",

--- a/app/templates/configure.html
+++ b/app/templates/configure.html
@@ -413,6 +413,11 @@ block content %}
     </div>
   </main>
 </div>
+<div
+  id="weatherHoverTooltip"
+  class="pointer-events-none fixed z-[100] hidden max-w-44 border-2 border-black bg-black px-2 py-1 text-[10px] font-normal normal-case leading-tight text-white shadow-neo-sm"
+  style="z-index: 9999"
+></div>
 {% endblock %} {% block scripts %}
 <script>
   // Country to ISO code mapping for flag images
@@ -782,9 +787,8 @@ block content %}
     );
     if (weatherRaceDayBtnMobile)
       weatherRaceDayBtnMobile.textContent = t.weatherRaceDayLabel;
-    const weatherTooltipText = document.getElementById("weatherTooltipText");
-    if (weatherTooltipText)
-      weatherTooltipText.textContent = t.weatherTooltipText;
+    const weatherHoverTooltip = document.getElementById("weatherHoverTooltip");
+    if (weatherHoverTooltip) weatherHoverTooltip.textContent = t.weatherTooltipText;
     const displayLabel = document.getElementById("displayLabel");
     if (displayLabel) displayLabel.textContent = t.displayLabel;
     const displayLabelMobile = document.getElementById("displayLabelMobile");
@@ -801,6 +805,91 @@ block content %}
       }
     });
     renderTzList();
+  }
+
+  function positionWeatherHoverTooltip(x, y) {
+    const tooltip = document.getElementById("weatherHoverTooltip");
+    if (!tooltip || tooltip.classList.contains("hidden")) return;
+
+    const margin = 12;
+    const tooltipWidth = tooltip.offsetWidth;
+    const tooltipHeight = tooltip.offsetHeight;
+    const sidebar = document.getElementById("settingsSidebar");
+    const sidebarRect =
+      sidebar && window.innerWidth >= 1024
+        ? sidebar.getBoundingClientRect()
+        : null;
+    const minLeft =
+      sidebarRect && x <= sidebarRect.right
+        ? sidebarRect.right + margin
+        : 8;
+    const maxLeft = window.innerWidth - tooltipWidth - 8;
+
+    let left = x + margin;
+    let top = y - tooltipHeight - margin;
+
+    if (left > maxLeft) left = maxLeft;
+    if (left < minLeft) left = minLeft;
+    if (left < 8) left = 8;
+
+    if (top < 8) {
+      top = y + margin;
+    }
+    if (top + tooltipHeight > window.innerHeight - 8) {
+      top = window.innerHeight - tooltipHeight - 8;
+    }
+    if (top < 8) top = 8;
+
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
+  }
+
+  function showWeatherHoverTooltip(event) {
+    const tooltip = document.getElementById("weatherHoverTooltip");
+    if (!tooltip || !event.currentTarget?.disabled) return;
+
+    tooltip.textContent = uiText.weatherTooltipText;
+    tooltip.classList.remove("hidden");
+    positionWeatherHoverTooltip(event.clientX, event.clientY);
+  }
+
+  function moveWeatherHoverTooltip(event) {
+    positionWeatherHoverTooltip(event.clientX, event.clientY);
+  }
+
+  function hideWeatherHoverTooltip() {
+    const tooltip = document.getElementById("weatherHoverTooltip");
+    if (!tooltip) return;
+
+    tooltip.classList.add("hidden");
+    tooltip.style.removeProperty("left");
+    tooltip.style.removeProperty("top");
+  }
+
+  function showWeatherHoverTooltipFromFocus(event) {
+    if (!event.currentTarget?.disabled) return;
+
+    const rect = event.currentTarget.getBoundingClientRect();
+    showWeatherHoverTooltip({
+      currentTarget: event.currentTarget,
+      clientX: rect.right,
+      clientY: rect.top + rect.height / 2,
+    });
+  }
+
+  function initializeWeatherTooltips() {
+    document
+      .querySelectorAll("[data-weather-tooltip-trigger]")
+      .forEach((trigger) => {
+        if (trigger.dataset.tooltipBound === "true") return;
+
+        trigger.addEventListener("mouseenter", showWeatherHoverTooltip);
+        trigger.addEventListener("mousemove", moveWeatherHoverTooltip);
+        trigger.addEventListener("mouseleave", hideWeatherHoverTooltip);
+        trigger.addEventListener("focus", showWeatherHoverTooltipFromFocus);
+        trigger.addEventListener("blur", hideWeatherHoverTooltip);
+        trigger.dataset.tooltipBound = "true";
+      });
   }
 
   function getApiUrl() {
@@ -1752,6 +1841,7 @@ block content %}
     }
 
     initScreenTypeVisibility();
+    initializeWeatherTooltips();
     setUiLanguage(currentUiLang);
 
     if (currentScreenType === "calendar") {

--- a/app/templates/configure.html
+++ b/app/templates/configure.html
@@ -415,6 +415,8 @@ block content %}
 </div>
 <div
   id="weatherHoverTooltip"
+  role="tooltip"
+  aria-hidden="true"
   class="pointer-events-none fixed z-[9999] hidden max-w-44 border-2 border-black bg-black px-2 py-1 text-[10px] font-normal normal-case leading-tight text-white shadow-neo-sm"
 ></div>
 {% endblock %} {% block scripts %}
@@ -852,6 +854,7 @@ block content %}
     if (!tooltip || !isWeatherTooltipDisabledState(event.currentTarget)) return;
 
     tooltip.textContent = uiText.weatherTooltipText;
+    tooltip.setAttribute("aria-hidden", "false");
     tooltip.classList.remove("hidden");
     positionWeatherHoverTooltip(event.clientX, event.clientY);
   }
@@ -864,6 +867,7 @@ block content %}
     const tooltip = document.getElementById("weatherHoverTooltip");
     if (!tooltip) return;
 
+    tooltip.setAttribute("aria-hidden", "true");
     tooltip.classList.add("hidden");
     tooltip.style.removeProperty("left");
     tooltip.style.removeProperty("top");
@@ -1712,6 +1716,7 @@ block content %}
       if (!btn) return;
       if (isRaceDayAvailable) {
         btn.setAttribute("aria-disabled", "false");
+        btn.removeAttribute("aria-describedby");
         btn.classList.remove(
           "opacity-50",
           "cursor-not-allowed",
@@ -1722,6 +1727,7 @@ block content %}
         btn.classList.add("border-black", "hover:bg-black", "hover:text-white");
       } else {
         btn.setAttribute("aria-disabled", "true");
+        btn.setAttribute("aria-describedby", "weatherHoverTooltip");
         btn.classList.remove(
           "bg-racing-red",
           "bg-black",

--- a/app/templates/configure/_calendar_sidebar.html
+++ b/app/templates/configure/_calendar_sidebar.html
@@ -88,9 +88,9 @@
   <div id="tzList" class="flex-1 overflow-y-auto text-xs p-2 space-y-0.5"></div>
 
   <div class="flex-shrink-0 px-2 py-1.5 border-t-2 border-black bg-gray-50" id="weatherContainer">
-    <label class="text-xs font-bold uppercase mb-1.5 block" id="weatherLabel"
-      >Weather</label
-    >
+    <div class="mb-1.5 flex items-center gap-1">
+      <label class="text-xs font-bold uppercase" id="weatherLabel">Weather</label>
+    </div>
     <input
       type="checkbox"
       id="weatherToggle"
@@ -122,15 +122,10 @@
         type="button"
         onclick="setWeatherType('race_day')"
         id="weatherRaceDayBtn"
-        class="weather-type-btn group relative flex-1 px-2 py-0.5 text-[9px] font-bold uppercase text-center border border-black transition-all bg-racing-red text-white"
+        class="weather-type-btn flex-1 px-2 py-0.5 text-[9px] font-bold uppercase text-center border border-black transition-all bg-racing-red text-white"
+        data-weather-tooltip-trigger
       >
         <span id="weatherRaceDayText">Race day</span>
-        <span
-          id="weatherRaceDayTooltip"
-          class="invisible group-hover:visible group-disabled:visible absolute left-1/2 -translate-x-1/2 bottom-full mb-1 px-2 py-1 bg-black text-white text-[10px] whitespace-nowrap z-50 border-2 border-white"
-        >
-          <span id="weatherTooltipText">Activates 14 days before race</span>
-        </span>
       </button>
     </div>
     <input type="radio" name="weatherType" value="current" class="hidden" />
@@ -188,9 +183,11 @@
 
 <!-- Weather - Mobile -->
 <div class="lg:hidden p-3 border-b-2 border-black bg-gray-50" id="mobileWeatherContainer">
-  <label class="block text-xs font-bold uppercase mb-2" id="weatherLabelMobile"
-    >Weather</label
-  >
+  <div class="mb-2 flex items-center gap-1">
+    <label class="block text-xs font-bold uppercase" id="weatherLabelMobile"
+      >Weather</label
+    >
+  </div>
   <div class="grid grid-cols-3 gap-1">
     <button
       type="button"
@@ -213,6 +210,7 @@
       onclick="setWeatherType('race_day')"
       id="weatherRaceDayBtnMobile"
       class="weather-type-btn-mobile min-w-0 px-2 py-2 text-[11px] font-bold uppercase text-center border-2 border-black transition-all bg-racing-red text-white"
+      data-weather-tooltip-trigger
     >
       Race Day
     </button>

--- a/app/templates/home.html
+++ b/app/templates/home.html
@@ -152,7 +152,7 @@ block og_tags %}
         <div style="display: flex; flex-direction: column; gap: 8px">
           <div style="display: grid; grid-template-columns: 92px auto; column-gap: 10px; align-items: baseline">
             <span class="text-[10px] tracking-[0.18em] text-gray-500 text-left whitespace-nowrap"
-              >Inspired by</span
+              >Inspiration</span
             >
             <a
               href="https://x.com/foxeelab/status/1761498129268981856"
@@ -171,7 +171,7 @@ block og_tags %}
               target="_blank"
               rel="noopener noreferrer"
               class="block min-w-0 text-left hover:text-racing-red"
-              >Jolpica</a
+              >Jolpica-F1 API</a
             >
           </div>
           <div style="display: grid; grid-template-columns: 92px auto; column-gap: 10px; align-items: baseline">
@@ -195,7 +195,7 @@ block og_tags %}
               target="_blank"
               rel="noopener noreferrer"
               class="block min-w-0 text-left hover:text-racing-red"
-              >Icons</a
+              >Weather-icons</a
             >
           </div>
           <div style="display: grid; grid-template-columns: 92px auto; column-gap: 10px; align-items: baseline">

--- a/package-lock.json
+++ b/package-lock.json
@@ -536,9 +536,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -974,9 +974,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/uv.lock
+++ b/uv.lock
@@ -752,11 +752,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.2"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- clear the GitHub security alerts by updating the vulnerable lockfile dependencies
- harden remaining public-page redirects by routing them through the validated `_redirect_path()` helper
- refresh the calendar configure weather tooltip so it stays visible, works from `aria-disabled` state, and no longer depends on native disabled-button hover behavior
- sync homepage/desktop credits labels with the mobile credits wording and expand the public attribution rows
- document the full PR scope in `CHANGELOG.md` and ignore local `.playwright-cli/` artifacts going forward

## Testing
- `uv run pytest tests/test_release_validation.py`
- `uv run pytest tests/test_main.py -k 'redirect or changelog_lang_parameter or changelog_hides_empty_unreleased_heading or changelog_has_no_collapsible_sections or stats_dashboard'`
- verified the configure calendar tooltip locally against the running dev server with Playwright (`disabled=false`, `aria-disabled=true`, tooltip visible on hover)

## Checklist
- [x] Changelog updated for all changes in this PR versus `main`
- [x] Review feedback addressed for actionable comments
- [x] Local targeted tests passed for changelog and redirect coverage
- [x] CI re-triggered on the latest branch SHA after fixes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive, pointer-following tooltip for weather availability hints with keyboard accessibility support.

* **Improvements**
  * Updated credits section with reorganized attribution labels and clearer provider information.
  * Enhanced security for page redirects with improved validation.

* **Chores**
  * Updated dependencies for security patches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->