### PR TITLE
[codex] Invalidate stale locale cache for locale switching

### DIFF
--- a/app/assets/js/sw.js
+++ b/app/assets/js/sw.js
@@ -1,4 +1,6 @@
-const CACHE_NAME = "f1-eink-v2";
+// Bump the cache version whenever routing-critical frontend assets change.
+// This forces clients to drop stale locale-switching logic from previous releases.
+const CACHE_NAME = "f1-eink-v3";
 const STATIC_ASSETS = [
     "/static/css/tailwind.min.css",
     "/static/css/styles.css",


### PR DESCRIPTION
## Summary
- bump the service worker cache version so browsers drop stale cached frontend assets
- force clients to refresh the locale-switching logic delivered in `common.js`
- prevent stale clients from generating repeated language prefixes such as `/es/es/...` or `/de/es/...`

## Issue
Users reported that switching the UI language to `es` or `de` could start an infinite redirect-like loop where the URL kept growing:

`https://f1.inkycloud.click/es/es/es/...`

The current repository code no longer reproduces that behavior in a fresh session, which made this look inconsistent across browsers.

## Root Cause
The live app serves the correct locale-switching code now, but the service worker caches `/static/js/common.js` under a stable cache key.

Clients that had an older cached `common.js` from the early subdirectory-language rollout still used locale logic that only understood `cs` and `en`. On paths like `/es/configure/calendar`, that stale code failed to strip the existing locale prefix and built the next URL from the already-prefixed path, producing values like:

- `/es/es/configure/calendar`
- `/de/es/configure/calendar`

Once that stale asset was active, every language switch could add another locale segment.

## Fix
This PR bumps the service worker cache name from `f1-eink-v2` to `f1-eink-v3` in `app/assets/js/sw.js`.

That invalidates old cached static assets and forces affected browsers to fetch the current `common.js`, which correctly handles all supported locale prefixes.

## Validation
- verified the current production site in a fresh automated browser session: `EN -> ES -> DE -> ES` worked on both `/` and `/es/configure/calendar`
- confirmed the old cached locale logic would generate `/es/es/...` from `/es/configure/calendar`
- no automated test run for this PR because the change only invalidates a stale service-worker cache key
