### PR TITLE
docs: add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+This is a single-service Python/FastAPI application (F1 E-Ink Calendar) that generates 800x480 BMP images for E-Ink displays. It uses an embedded SQLite database — no external database servers are required.
+
+### Running the dev server
+
+```bash
+source /workspace/venv/bin/activate
+uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+```
+
+The server starts on http://localhost:8000. Key endpoints:
+- `GET /health` — health check
+- `GET /calendar.bmp?lang=en` — calendar BMP image
+- `GET /teams.bmp?lang=en` — teams BMP image
+- `GET /en/configure/calendar` — interactive calendar config page
+
+### Lint and test
+
+```bash
+source /workspace/venv/bin/activate
+ruff check .          # linting
+ruff format --check . # format check
+pytest                # test suite (expect 2 pre-existing failures on stats auth tests)
+```
+
+The 2 test failures in `test_api_stats_endpoint_returns_correct_structure` and `test_api_stats_history_endpoint_returns_hourly_history` are pre-existing — they test admin-token-protected endpoints without providing a token.
+
+### Environment setup notes
+
+- Python 3.13+ is required (installed from deadsnakes PPA).
+- The virtualenv lives at `/workspace/venv`.
+- `.env` is copied from `.env.local.example` for local development (relative paths for `DATABASE_PATH` and `IMAGES_PATH`).
+- The `data/` directory must exist for SQLite and image storage.
+- No external services (Redis, PostgreSQL, Docker) are needed — SQLite is embedded and API calls to Jolpica/Open-Meteo go to public endpoints.
+- TailwindCSS (Node.js) is only needed if modifying CSS files; pre-compiled CSS is checked in.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development instructions including:
- Dev server startup commands
- Lint and test commands (with notes on pre-existing test failures)
- Environment setup notes (Python 3.13, virtualenv, .env, data directory)
- Clarification that no external services are needed

## Testing

- `ruff check .` — all checks passed
- `ruff format --check .` — 99 files already formatted
- `pytest` — 471 passed, 2 pre-existing auth-related failures
- `uvicorn app.main:app --reload` — server starts and serves all endpoints
- `curl http://localhost:8000/health` — returns `{"status":"healthy"}`
- `curl http://localhost:8000/calendar.bmp?lang=en` — returns valid 800x480 1-bit BMP
- `curl http://localhost:8000/teams.bmp?lang=en` — returns valid 800x480 1-bit BMP

## Screenshots

[f1_eink_calendar_web_demo.mp4](https://cursor.com/agents/bc-62ffa3b1-b6ae-47e7-83fa-46854493207d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ff1_eink_calendar_web_demo.mp4)

[Landing page](https://cursor.com/agents/bc-62ffa3b1-b6ae-47e7-83fa-46854493207d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_page.webp)
[Calendar configuration page](https://cursor.com/agents/bc-62ffa3b1-b6ae-47e7-83fa-46854493207d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar_configure.webp)
[Calendar BMP output](https://cursor.com/agents/bc-62ffa3b1-b6ae-47e7-83fa-46854493207d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcalendar_bmp_output.webp)

## Checklist

- [x] I read the Code of Conduct and this change follows it.
- [x] I added or updated documentation as needed.
- [x] I verified error handling and logging are appropriate for FastAPI endpoints.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62ffa3b1-b6ae-47e7-83fa-46854493207d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62ffa3b1-b6ae-47e7-83fa-46854493207d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

