### PR TITLE
[codex] Retain full-year statistics history

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,9 +58,9 @@ IMAGES_PATH=/app/data/images
 
 # Scheduler Configuration
 SCHEDULER_ENABLED=true
-# Statistics retention in days. 0 (default) keeps all history forever;
-# set e.g. 90 to opt into pruning and bound stats table/backup growth.
-STATS_RETENTION_DAYS=90
+# Statistics retention in days. Default 400 preserves the full 365-day dashboard
+# while bounding stats table/backup growth. Set 0 to keep all history forever.
+STATS_RETENTION_DAYS=400
 
 # Weather Configuration
 OPEN_METEO_ARCHIVE_URL=https://archive-api.open-meteo.com/v1/archive

--- a/.env.local.example
+++ b/.env.local.example
@@ -54,9 +54,9 @@ DISPLAY_WIDTH=800
 
 # Scheduler Configuration
 SCHEDULER_ENABLED=true
-# Statistics retention in days. 0 (default) keeps all history forever;
-# set e.g. 90 to opt into pruning and bound stats table/backup growth.
-STATS_RETENTION_DAYS=90
+# Statistics retention in days. Default 400 preserves the full 365-day dashboard
+# while bounding stats table/backup growth. Set 0 to keep all history forever.
+STATS_RETENTION_DAYS=400
 
 # Weather Configuration
 OPEN_METEO_ARCHIVE_URL=https://archive-api.open-meteo.com/v1/archive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.32] - 2026-07-11
+
+### Backend
+
+#### Fixed
+
+- **Full-year statistics retention** - Retain 400 days of statistics by default so the `365D` dashboard remains complete while database and backup growth stay bounded; deployments explicitly configured for 90 days must switch to `400` or `0` and redeploy
+
 ## [1.2.31] - 2026-07-09
 
 ### Security
@@ -29,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Persistent F1 data** - Store mutable circuit history beside the SQLite database, reload atomic file versions without restarting, preserve maintained history during scraping, and mark daily refreshes complete only after a successful upstream run
 - **Upstream resilience** - Share the configured Jolpica base URL, coalesce standings fetches, cache bounded misses, honor `Retry-After` with jitter, and serve the latest completed race during an empty off-season calendar
 - **Rendering correctness and efficiency** - Select active team drivers by round, enforce the fixed 800x480 canvas, use a 64 MiB decoded-asset cache, accelerate BWR/BWRY palette mapping, reuse cached fallback tracks, and pluralize countdown units per locale including French and Brazilian Portuguese zero forms
-- **Storage durability** - Fsync atomic files and parent directories with unsupported-filesystem fallbacks, serialize cancellation-safe schema setup, close partially configured SQLite connections, retain 400 days of statistics by default so the 365-day dashboard remains complete, cap performance samples, report percentile sample sizes, and remove reset sidecars safely
+- **Storage durability** - Fsync atomic files and parent directories with unsupported-filesystem fallbacks, serialize cancellation-safe schema setup, close partially configured SQLite connections, cap statistics history and performance samples, report percentile sample sizes, and remove reset sidecars safely
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Full-year statistics retention** - Retain 400 days of statistics by default so the `365D` dashboard remains complete while database and backup growth stay bounded; deployments explicitly configured for 90 days must switch to `400` or `0` and redeploy
 
+### Development
+
+#### Fixed
+
+- **Post-release CI validation** - Isolate the release-validation entrypoint test from repository tags so the tagged release commit passes `main` CI without weakening the pull-request version-bump gate
+
 ## [1.2.31] - 2026-07-09
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Persistent F1 data** - Store mutable circuit history beside the SQLite database, reload atomic file versions without restarting, preserve maintained history during scraping, and mark daily refreshes complete only after a successful upstream run
 - **Upstream resilience** - Share the configured Jolpica base URL, coalesce standings fetches, cache bounded misses, honor `Retry-After` with jitter, and serve the latest completed race during an empty off-season calendar
 - **Rendering correctness and efficiency** - Select active team drivers by round, enforce the fixed 800x480 canvas, use a 64 MiB decoded-asset cache, accelerate BWR/BWRY palette mapping, reuse cached fallback tracks, and pluralize countdown units per locale including French and Brazilian Portuguese zero forms
-- **Storage durability** - Fsync atomic files and parent directories with unsupported-filesystem fallbacks, serialize cancellation-safe schema setup, close partially configured SQLite connections, cap statistics history and performance samples, report percentile sample sizes, and remove reset sidecars safely
+- **Storage durability** - Fsync atomic files and parent directories with unsupported-filesystem fallbacks, serialize cancellation-safe schema setup, close partially configured SQLite connections, retain 400 days of statistics by default so the 365-day dashboard remains complete, cap performance samples, report percentile sample sizes, and remove reset sidecars safely
 
 #### Changed
 

--- a/COOLIFY.md
+++ b/COOLIFY.md
@@ -854,4 +854,4 @@ After successful deployment:
 
 _Last updated: July 2026_
 _Coolify version: 4.x+_  
-_InkyCloud-F1 version: 1.2.31+_
+_InkyCloud-F1 version: 1.2.32+_

--- a/COOLIFY.md
+++ b/COOLIFY.md
@@ -106,9 +106,14 @@ SENTRY_ENVIRONMENT=production
 UMAMI_ENABLED=true
 UMAMI_WEBSITE_ID=your-website-id
 UMAMI_API_URL=https://your-analytics-domain.com/api/send
+STATS_RETENTION_DAYS=400
 ```
 
 `SITE_URL` must match the public apex domain of this deployment. It is used for canonical tags, `robots.txt`, `sitemap.xml`, Open Graph URLs, and the app-level `www` redirect. It is separate from `ANALYTICS_HOSTNAME`.
+
+Keep `STATS_RETENTION_DAYS` at `400` or set it to `0` (unlimited) for a complete `365D`
+statistics view. Existing deployments configured with `90` must update the Coolify environment
+variable and redeploy. Previously pruned rows cannot be reconstructed.
 
 ### Step 4: Deploy
 
@@ -163,6 +168,12 @@ Average build time: **2-3 minutes**
 | `APP_HOST` | `0.0.0.0` | Bind address (always 0.0.0.0 in containers) |
 | `APP_PORT` | `8000`    | Application port                            |
 | `DEBUG`    | `false`   | Debug mode (use `false` in production)      |
+
+### Optional - Statistics Retention
+
+| Variable               | Default | Description                                                       |
+| ---------------------- | ------- | ----------------------------------------------------------------- |
+| `STATS_RETENTION_DAYS` | `400`   | Days to retain statistics (`0` = unlimited; keep at least `365`) |
 
 ### Optional - Monitoring
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -144,6 +144,9 @@ ANALYTICS_HOSTNAME=f1.yourdomain.com
 JOLPICA_API_URL=https://api.jolpi.ca/ergast/f1/current/next.json
 REQUEST_TIMEOUT=10
 
+# Statistics (400 preserves the full 365-day dashboard; 0 keeps all history)
+STATS_RETENTION_DAYS=400
+
 # Language
 DEFAULT_LANG=en
 ```

--- a/SELF-HOSTING.md
+++ b/SELF-HOSTING.md
@@ -298,6 +298,7 @@ IMAGES_PATH=/app/data/images
 
 # Scheduler Configuration
 SCHEDULER_ENABLED=true
+STATS_RETENTION_DAYS=400
 ```
 
 `SITE_URL` is required for correct canonical tags, `robots.txt`, `sitemap.xml`, Open Graph URLs, and the app-level `www` to apex redirect. `ANALYTICS_HOSTNAME` only affects analytics reporting and does not replace `SITE_URL`.
@@ -318,6 +319,7 @@ SCHEDULER_ENABLED=true
 | `DATABASE_PATH`                                                 | `/app/data/f1.db`  | SQLite database location (absolute path for containers) |
 | `IMAGES_PATH`                                                   | `/app/data/images` | Generated preview images (absolute path for containers) |
 | `SCHEDULER_ENABLED`                                             | `true`             | Background data refresh                                 |
+| `STATS_RETENTION_DAYS`                                          | `400`              | Statistics history in days (`0` = unlimited; use at least `365` for the full dashboard range) |
 | `BACKUP_ENABLED`                                                | `false`            | Enable S3 database backup                               |
 | `BACKUP_CRON`                                                   | `0 3 * * *`        | Backup schedule (cron expression)                       |
 | `BACKUP_RETENTION_DAYS`                                         | `30`               | Days to keep old backups (0 = keep all)                 |

--- a/app/config.py
+++ b/app/config.py
@@ -159,11 +159,12 @@ class Config(BaseSettings):
     # Scheduler settings
     SCHEDULER_ENABLED: bool = Field(True, description="Toggle background scheduler")
     STATS_RETENTION_DAYS: int = Field(
-        90,
+        400,
         ge=0,
         description=(
-            "Days to retain API/request/performance statistics. Default 90 bounds database and "
-            "backup growth; set 0 only to explicitly retain history forever"
+            "Days to retain API/request/performance statistics. Default 400 preserves the full "
+            "365-day dashboard while bounding database and backup growth; set 0 to retain "
+            "history forever"
         ),
     )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "f1-eink-calendar",
-  "version": "1.2.31",
+  "version": "1.2.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "f1-eink-calendar",
-      "version": "1.2.31",
+      "version": "1.2.32",
       "devDependencies": {
         "@tailwindcss/cli": "^4.3.2",
         "tailwindcss": "^4.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f1-eink-calendar",
-  "version": "1.2.31",
+  "version": "1.2.32",
   "private": true,
   "scripts": {
     "build:css": "tailwindcss -i ./app/assets/css/input.css -o ./app/assets/css/tailwind.min.css --minify",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "f1-eink-cal"
-version = "1.2.31"
+version = "1.2.32"
 description = "F1 E-Ink calendar service generating 800x480 1-bit BMPs for LaskaKit displays"
 readme = "README.md"
 authors = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,6 +39,14 @@ def test_config_defaults():
     assert config.DISPLAY_HEIGHT == 480
     assert config.DEFAULT_LANG in config_module.LANGUAGE_CODES
     assert config.STATS_RATE_LIMIT_PER_MINUTE == 60
+    assert config.STATS_RETENTION_DAYS == 400
+
+
+def test_default_stats_retention_covers_longest_dashboard_range():
+    """The shipped retention must preserve every selectable dashboard range."""
+    config = config_module.Config(_env_file=None)
+
+    assert config.STATS_RETENTION_DAYS == 0 or config.STATS_RETENTION_DAYS >= 365
 
 
 @pytest.mark.parametrize("field_name", ["DATABASE_PATH", "IMAGES_PATH"])
@@ -60,6 +68,7 @@ def test_shipped_example_env_files_boot(env_file, monkeypatch):
     config = config_module.Config(_env_file=env_file)
 
     assert config.ADMIN_API_TOKEN is None
+    assert config.STATS_RETENTION_DAYS == 400
 
 
 @pytest.mark.parametrize(
@@ -106,7 +115,7 @@ def test_config_invalid_env_falls_back(monkeypatch):
     assert str(config.OPEN_METEO_ARCHIVE_URL) == "https://archive-api.open-meteo.com/v1/archive"
     assert config.SENTRY_TRACES_SAMPLE_RATE == 0.1
     assert config.DEFAULT_LANG == "en"
-    assert config.STATS_RETENTION_DAYS == 90
+    assert config.STATS_RETENTION_DAYS == 400
 
 
 def test_translator_english():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,9 +44,9 @@ def test_config_defaults():
 
 def test_default_stats_retention_covers_longest_dashboard_range():
     """The shipped retention must preserve every selectable dashboard range."""
-    config = config_module.Config(_env_file=None)
+    default_retention = config_module.Config.model_fields["STATS_RETENTION_DAYS"].default
 
-    assert config.STATS_RETENTION_DAYS == 0 or config.STATS_RETENTION_DAYS >= 365
+    assert default_retention == 0 or default_retention >= 365
 
 
 @pytest.mark.parametrize("field_name", ["DATABASE_PATH", "IMAGES_PATH"])
@@ -64,6 +64,7 @@ def test_config_treats_explicitly_empty_admin_token_as_unset():
 @pytest.mark.parametrize("env_file", [".env.example", ".env.local.example"])
 def test_shipped_example_env_files_boot(env_file, monkeypatch):
     monkeypatch.delenv("ADMIN_API_TOKEN", raising=False)
+    monkeypatch.delenv("STATS_RETENTION_DAYS", raising=False)
 
     config = config_module.Config(_env_file=env_file)
 

--- a/tests/test_release_validation.py
+++ b/tests/test_release_validation.py
@@ -224,8 +224,11 @@ def test_release_validation_main_reports_success(latest_tag, monkeypatch, capsys
     assert f"latest tag {latest_tag or 'none'}" in output
 
 
-def test_release_validation_module_entrypoint():
+def test_release_validation_module_entrypoint(monkeypatch, capsys):
+    monkeypatch.setattr(release_validation.subprocess, "check_output", lambda *_a, **_k: "")
+
     with pytest.raises(SystemExit) as exc_info:
         runpy.run_path(str(release_validation.__file__), run_name="__main__")
 
     assert exc_info.value.code == 0
+    assert "latest tag none" in capsys.readouterr().out

--- a/uv.lock
+++ b/uv.lock
@@ -266,7 +266,7 @@ wheels = [
 
 [[package]]
 name = "f1-eink-cal"
-version = "1.2.31"
+version = "1.2.32"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Increase the default statistics retention from 90 to 400 days so the `365D` dashboard range can remain complete.
- Align both example environment files and self-hosting, deployment, and Coolify guidance with the bounded default.
- Add hermetic regression coverage for the retention configuration and release-validation entrypoint.
- Ensure tagged release commits pass `main` CI without weakening the pull-request version-bump gate.
- Publish the corrections as release 1.2.32 with synchronized Python, Node, and lockfile metadata.

## Root cause

The dashboard correctly maps `365D` to 8,760 hours, but the hardened configuration pruned `request_stats`, `api_calls`, and `perf_metrics` after 90 days by default. The yearly view therefore could not accumulate more than roughly three months of data.

Separately, the release-validation entrypoint test read live repository tags. Immediately after a release was tagged, the test interpreted the expected equality between the changelog version and tag as an unbumped pull request and failed the `main` push workflow. The actual pull-request gate remains strict.

## Impact

- New/default deployments retain 400 days, preserving the full yearly view while still bounding SQLite and backup growth.
- Deployments with an explicit `STATS_RETENTION_DAYS=90` must change it to `400` (or `0` for unlimited history) and redeploy.
- Rows already pruned cannot be reconstructed; the visible range will grow as new data accumulates.
- Post-release `main` CI no longer depends on the repository's current tags, while pull requests still must publish a changelog version newer than the latest tag.

## Testing

- `uv run pytest tests/ -v -m 'not benchmark' --cov=app --cov-branch --cov-fail-under=100 --cov-report=term-missing --cov-report=xml` (`979 passed`, `6 deselected`; `6502/6502` statements and `1704/1704` branches).
- `uv run pytest -W error tests/test_release_validation.py -v` (`17 passed`).
- `uv run interrogate -c pyproject.toml app scripts` (`796/796`, `100%`).
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy`
- Benchmark suite (`6 passed`).
- `uv lock --check`
- Release validation (`1.2.32` against tag `v1.2.31`), actionlint, and zizmor workflow audit.
- Clean no-cache Docker build from commit `29186d4`.
- Container smoke test from commit `29186d4`: default retention `400`, healthy `/health`, API version `1.2.32`, and `/stats?range=365d` returns `200`.

## Screenshots

Not applicable. This change affects retention configuration, tests, CI reliability, and documentation; rendered BMP output is unchanged.

## Checklist

- [x] I read the Code of Conduct and this change follows it.
- [x] I added or updated documentation as needed.
- [x] I verified error handling and logging are appropriate for FastAPI endpoints (no endpoint behavior changed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Statistics are now retained for 400 days by default, preserving the complete 365-day dashboard range.
  * Set retention to `0` to keep statistics indefinitely.

* **Documentation**
  * Deployment and self-hosting guides now explain statistics retention configuration and migration from the previous 90-day default.
  * Updated release documentation for version 1.2.32.

* **Bug Fixes**
  * Improved release validation so tagged release commits pass continuous integration checks reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
