### PR TITLE
fix(jolpica): coordinate follow-up refresh safeguards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,8 @@ ADMIN_API_TOKEN=
 DATA_API_RATE_LIMIT_PER_MINUTE=120
 IMAGE_RATE_LIMIT_PER_MINUTE=120
 JOLPICA_API_URL=https://api.jolpi.ca/ergast/f1/current/next.json
+# Six tokens cover one teams cache miss (four primary plus two standings requests).
+JOLPICA_BURST_CAPACITY=6
 JOLPICA_MIN_REQUEST_INTERVAL=2.0
 JOLPICA_MAX_RETRIES=6
 PERF_METRICS_RATE_LIMIT_PER_MINUTE=240
@@ -60,6 +62,8 @@ IMAGES_PATH=/app/data/images
 
 # Scheduler Configuration
 SCHEDULER_ENABLED=true
+# Maximum wall-clock runtime for one historical refresh (90 minutes).
+HISTORICAL_REFRESH_TIMEOUT_SECONDS=5400
 # Statistics retention in days. Default 400 preserves the full 365-day dashboard
 # while bounding stats table/backup growth. Set 0 to keep all history forever.
 STATS_RETENTION_DAYS=400

--- a/.env.example
+++ b/.env.example
@@ -61,9 +61,9 @@ DATABASE_PATH=/app/data/f1.db
 IMAGES_PATH=/app/data/images
 
 # Scheduler Configuration
-SCHEDULER_ENABLED=true
 # Maximum wall-clock runtime for one historical refresh (90 minutes).
 HISTORICAL_REFRESH_TIMEOUT_SECONDS=5400
+SCHEDULER_ENABLED=true
 # Statistics retention in days. Default 400 preserves the full 365-day dashboard
 # while bounding stats table/backup growth. Set 0 to keep all history forever.
 STATS_RETENTION_DAYS=400

--- a/.env.local.example
+++ b/.env.local.example
@@ -39,6 +39,8 @@ ADMIN_API_TOKEN=
 DATA_API_RATE_LIMIT_PER_MINUTE=120
 IMAGE_RATE_LIMIT_PER_MINUTE=120
 JOLPICA_API_URL=https://api.jolpi.ca/ergast/f1/current/next.json
+# Six tokens cover one teams cache miss (four primary plus two standings requests).
+JOLPICA_BURST_CAPACITY=6
 JOLPICA_MIN_REQUEST_INTERVAL=2.0
 JOLPICA_MAX_RETRIES=6
 PERF_METRICS_RATE_LIMIT_PER_MINUTE=240
@@ -56,6 +58,8 @@ DISPLAY_WIDTH=800
 
 # Scheduler Configuration
 SCHEDULER_ENABLED=true
+# Maximum wall-clock runtime for one historical refresh (90 minutes).
+HISTORICAL_REFRESH_TIMEOUT_SECONDS=5400
 # Statistics retention in days. Default 400 preserves the full 365-day dashboard
 # while bounding stats table/backup growth. Set 0 to keep all history forever.
 STATS_RETENTION_DAYS=400

--- a/.env.local.example
+++ b/.env.local.example
@@ -57,9 +57,9 @@ DISPLAY_HEIGHT=480
 DISPLAY_WIDTH=800
 
 # Scheduler Configuration
-SCHEDULER_ENABLED=true
 # Maximum wall-clock runtime for one historical refresh (90 minutes).
 HISTORICAL_REFRESH_TIMEOUT_SECONDS=5400
+SCHEDULER_ENABLED=true
 # Statistics retention in days. Default 400 preserves the full 365-day dashboard
 # while bounding stats table/backup growth. Set 0 to keep all history forever.
 STATS_RETENTION_DAYS=400

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.37] - 2026-08-04
+
+### Backend
+
+#### Added
+
+- **Season rollover guard** - Fail the test suite once `SEASON_START_DATES` no longer covers the current UTC year so a missing first-race date cannot silently reintroduce empty-season Jolpica probes
+
+#### Changed
+
+- **Cross-service Jolpica pacing** - Share one event-loop-safe token bucket per upstream hostname, allowing a six-request teams cache-miss burst while keeping sustained historical, F1 fallback, standings, teams, and retry traffic paced
+- **Bounded historical refreshes** - Cap the nightly refresh at a configurable 90-minute wall-clock budget, persist completed circuit updates before cancellation, count timeouts as one incomplete run, and log elapsed duration for every execution
+
 ## [1.2.36] - 2026-08-03
 
 ### Backend

--- a/app/config.py
+++ b/app/config.py
@@ -123,7 +123,14 @@ class Config(BaseSettings):
     JOLPICA_MIN_REQUEST_INTERVAL: float = Field(
         2.0,
         gt=0,
-        description="Minimum gap between Jolpica requests in seconds",
+        description="Jolpica pacing-token refill interval in seconds",
+    )
+    JOLPICA_BURST_CAPACITY: int = Field(
+        6,
+        gt=0,
+        description=(
+            "Jolpica burst tokens; six covers one teams cache miss without overlap reserve"
+        ),
     )
     JOLPICA_MAX_RETRIES: int = Field(
         6,
@@ -169,6 +176,11 @@ class Config(BaseSettings):
 
     # Scheduler settings
     SCHEDULER_ENABLED: bool = Field(True, description="Toggle background scheduler")
+    HISTORICAL_REFRESH_TIMEOUT_SECONDS: int = Field(
+        5400,
+        gt=0,
+        description="Maximum wall-clock runtime for one historical refresh",
+    )
     STATS_RETENTION_DAYS: int = Field(
         400,
         ge=0,
@@ -238,7 +250,9 @@ class Config(BaseSettings):
 
     @field_validator(
         "REQUEST_TIMEOUT",
+        "JOLPICA_BURST_CAPACITY",
         "JOLPICA_MAX_RETRIES",
+        "HISTORICAL_REFRESH_TIMEOUT_SECONDS",
         "IMAGE_RATE_LIMIT_PER_MINUTE",
         "PERF_METRICS_RATE_LIMIT_PER_MINUTE",
         "DATA_API_RATE_LIMIT_PER_MINUTE",

--- a/app/services/f1_service.py
+++ b/app/services/f1_service.py
@@ -24,6 +24,7 @@ from app.services.circuit_data import get_circuits_data_path, load_circuits_data
 from app.services.circuit_metadata import CIRCUIT_ID_MAP
 from app.services.http_client import get_shared_http_client
 from app.utils.http import fetch_with_retry
+from app.utils.jolpica import get_jolpica_pacer
 from app.utils.timezones import UTC, ZoneInfoNotFoundError, get_timezone, normalize_timezone
 
 logger = logging.getLogger(__name__)
@@ -310,7 +311,12 @@ class F1Service:
             client = get_shared_http_client(httpx.AsyncClient, timeout=self.timeout)
             url = f"{self.api_base_url}/{year}.json"
             logger.info("Fetching season races from %s", url)
-            response = await fetch_with_retry(client, url, logger=logger)
+            response = await fetch_with_retry(
+                client,
+                url,
+                pacer=get_jolpica_pacer(self.api_base_url),
+                logger=logger,
+            )
 
             data = response.json()
             races = data.get("MRData", {}).get("RaceTable", {}).get("Races", [])
@@ -381,7 +387,12 @@ class F1Service:
             client = get_shared_http_client(httpx.AsyncClient, timeout=self.timeout)
             url = f"{self.api_base_url}/{year}/{round_num}.json"
             logger.info("Fetching race from %s", url)
-            response = await fetch_with_retry(client, url, logger=logger)
+            response = await fetch_with_retry(
+                client,
+                url,
+                pacer=get_jolpica_pacer(self.api_base_url),
+                logger=logger,
+            )
 
             data = response.json()
             races = data.get("MRData", {}).get("RaceTable", {}).get("Races", [])

--- a/app/services/historical_refresh.py
+++ b/app/services/historical_refresh.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 from collections.abc import Mapping
@@ -17,7 +18,7 @@ from app.services.http_client import get_shared_http_client
 from app.utils.atomic_io import atomic_write_json
 from app.utils.f1_season import get_current_f1_season
 from app.utils.http import AsyncPacer, fetch_with_retry, is_transient_http_status
-from app.utils.jolpica import get_jolpica_base_url
+from app.utils.jolpica import get_jolpica_base_url, get_jolpica_pacer
 from app.utils.material_diff import has_material_change
 from app.utils.result_entries import ResultEntry, get_result_mapping, sort_entries_by_position
 
@@ -133,6 +134,7 @@ async def _fetch_results_with_status(
     had_valid_response = False
     had_failure = False
     api_base = get_jolpica_base_url()
+    pacer = pacer or get_jolpica_pacer(api_base)
     for year in (current_year, current_year - 1, current_year - 2):
         try:
             qualifying_response = await fetch_with_retry(
@@ -269,30 +271,48 @@ async def main(circuit_filter: str | None = None) -> HistoricalRefreshResult:
         )
 
     client = get_shared_http_client(httpx.AsyncClient, timeout=30)
-    pacer = AsyncPacer(config.JOLPICA_MIN_REQUEST_INTERVAL)
-    for circuit_id in refresh_ids:
-        outcome = await _fetch_results_with_status(client, circuit_id, pacer=pacer)
-        results = outcome.results
-        if not outcome.completed:
-            failed_circuits.append(circuit_id)
-            if outcome.transient_only:
-                transient_failed_circuits.append(circuit_id)
-        if results:
-            existing_historical = circuits[circuit_id].get("historical")
-            if _would_regress_season(results, existing_historical):
-                logger.info(
-                    "Kept newer stored season %s for %s",
-                    existing_historical.get("season"),
-                    circuit_id,
-                )
-            elif has_material_historical_change(results, existing_historical):
-                circuits[circuit_id]["historical"] = results
-                updated_circuits.append(circuit_id)
-                logger.info("Updated %s historical results from %s", circuit_id, results["season"])
+    pacer = get_jolpica_pacer()
+    try:
+        for circuit_id in refresh_ids:
+            outcome = await _fetch_results_with_status(client, circuit_id, pacer=pacer)
+            results = outcome.results
+            if not outcome.completed:
+                failed_circuits.append(circuit_id)
+                if outcome.transient_only:
+                    transient_failed_circuits.append(circuit_id)
+            if results:
+                existing_historical = circuits[circuit_id].get("historical")
+                if _would_regress_season(results, existing_historical):
+                    logger.info(
+                        "Kept newer stored season %s for %s",
+                        existing_historical.get("season"),
+                        circuit_id,
+                    )
+                elif has_material_historical_change(results, existing_historical):
+                    circuits[circuit_id]["historical"] = results
+                    updated_circuits.append(circuit_id)
+                    logger.info(
+                        "Updated %s historical results from %s",
+                        circuit_id,
+                        results["season"],
+                    )
+                else:
+                    logger.debug("Historical results unchanged for %s", circuit_id)
             else:
-                logger.debug("Historical results unchanged for %s", circuit_id)
-        else:
-            logger.info("No complete historical data for %s", circuit_id)
+                logger.info("No complete historical data for %s", circuit_id)
+    except asyncio.CancelledError:
+        if updated_circuits:
+            try:
+                atomic_write_json(circuits_path, circuits)
+            except Exception:
+                logger.exception("Could not persist partial historical results after cancellation")
+            else:
+                logger.info(
+                    "Saved partial historical results to %s before cancellation (%s updated)",
+                    circuits_path,
+                    len(updated_circuits),
+                )
+        raise
 
     if updated_circuits:
         atomic_write_json(circuits_path, circuits)

--- a/app/services/scheduler_maintenance.py
+++ b/app/services/scheduler_maintenance.py
@@ -6,7 +6,9 @@ import asyncio
 import logging
 import weakref
 from datetime import datetime, timedelta, timezone
+from time import monotonic
 
+from app.config import config
 from app.services.database import get_database
 from app.services.historical_refresh import HistoricalRefreshResult
 from app.services.historical_refresh import main as update_historical_results
@@ -64,7 +66,12 @@ async def _store_incomplete_streak(streak: int) -> None:
         logger.warning("Could not persist historical refresh failure streak: %s", e)
 
 
-async def _report_incomplete_run(result: HistoricalRefreshResult) -> None:
+async def _report_incomplete_run(
+    result: HistoricalRefreshResult,
+    *,
+    failure_reason: str | None = None,
+    timeout_seconds: float | None = None,
+) -> None:
     """Log an incomplete run, escalating to error once it recurs across runs.
 
     The messages stay static so the error tracker groups every recurrence into one
@@ -72,12 +79,15 @@ async def _report_incomplete_run(result: HistoricalRefreshResult) -> None:
     """
     streak = await _read_incomplete_streak() + 1
     await _store_incomplete_streak(streak)
-    log_context = {
+    log_context: dict[str, object] = {
         "failed_circuits": list(result.failed_circuits),
         "transient_failed_circuits": list(result.transient_failed_circuits),
         "consecutive_incomplete_runs": streak,
         "advanced_freshness": result.can_advance_freshness,
+        "failure_reason": failure_reason,
     }
+    if timeout_seconds is not None:
+        log_context["timeout_seconds"] = timeout_seconds
     if streak >= _HISTORICAL_REFRESH_ALERT_AFTER_RUNS:
         logger.error(
             "Historical refresh has not completed for several consecutive runs",
@@ -87,41 +97,63 @@ async def _report_incomplete_run(result: HistoricalRefreshResult) -> None:
         logger.warning("Historical refresh incomplete", extra=log_context)
 
 
+async def _run_historical_refresh() -> None:
+    """Bound upstream refresh work, then persist its completion metadata."""
+    try:
+        async with asyncio.timeout(config.HISTORICAL_REFRESH_TIMEOUT_SECONDS):
+            result = await update_historical_results()
+        if result.updated_circuits:
+            logger.info(
+                "Historical results refreshed for %s circuits (%s); "
+                "hourly generation will publish relevant changes",
+                len(result.updated_circuits),
+                ", ".join(result.updated_circuits),
+            )
+        else:
+            logger.info("Historical results refresh completed with no material changes")
+        if result.completed:
+            await _store_incomplete_streak(0)
+        else:
+            await _report_incomplete_run(result)
+            if not result.can_advance_freshness:
+                return
+    except TimeoutError:
+        await _report_incomplete_run(
+            HistoricalRefreshResult((), (), 0),
+            failure_reason="timeout",
+            timeout_seconds=config.HISTORICAL_REFRESH_TIMEOUT_SECONDS,
+        )
+        return
+    except Exception as e:
+        logger.error("Error refreshing historical results: %s", e, exc_info=True)
+        return
+
+    try:
+        await get_database().set_cache_meta(
+            _HISTORICAL_REFRESH_META_KEY, datetime.now(timezone.utc).isoformat()
+        )
+    except Exception as e:  # noqa: BLE001 - timestamp persistence is best effort
+        logger.warning("Could not persist historical refresh timestamp: %s", e)
+
+
 async def refresh_historical_results() -> None:
-    """Refresh static historical results; hourly generation publishes any relevant change."""
+    """Run the static historical refresh once with overlap and runtime protection."""
     lock = get_loop_lock(_historical_refresh_locks)
     if lock.locked():
         logger.info("Historical results refresh already running; skipping overlapping trigger")
         return
 
     async with lock:
+        started_at = monotonic()
         try:
-            result = await update_historical_results()
-            if result.updated_circuits:
-                logger.info(
-                    "Historical results refreshed for %s circuits (%s); "
-                    "hourly generation will publish relevant changes",
-                    len(result.updated_circuits),
-                    ", ".join(result.updated_circuits),
-                )
-            else:
-                logger.info("Historical results refresh completed with no material changes")
-            if result.completed:
-                await _store_incomplete_streak(0)
-            else:
-                await _report_incomplete_run(result)
-                if not result.can_advance_freshness:
-                    return
-        except Exception as e:
-            logger.error("Error refreshing historical results: %s", e, exc_info=True)
-            return
-
-        try:
-            await get_database().set_cache_meta(
-                _HISTORICAL_REFRESH_META_KEY, datetime.now(timezone.utc).isoformat()
+            await _run_historical_refresh()
+        finally:
+            duration_seconds = monotonic() - started_at
+            logger.info(
+                "Historical refresh finished in %.2f seconds",
+                duration_seconds,
+                extra={"duration_seconds": duration_seconds},
             )
-        except Exception as e:
-            logger.warning("Could not persist historical refresh timestamp: %s", e)
 
 
 async def _historical_refresh_is_due() -> bool:

--- a/app/services/standings_service.py
+++ b/app/services/standings_service.py
@@ -14,7 +14,7 @@ from app.models import ConstructorStanding, DriverStanding, StandingsData
 from app.services.http_client import get_shared_http_client
 from app.utils.f1_season import is_supported_f1_season
 from app.utils.http import fetch_with_retry
-from app.utils.jolpica import get_jolpica_base_url
+from app.utils.jolpica import get_jolpica_base_url, get_jolpica_pacer
 
 logger = logging.getLogger(__name__)
 
@@ -132,9 +132,10 @@ class StandingsService:
         try:
             client = get_shared_http_client(httpx.AsyncClient, timeout=self.timeout)
             base_url = self._derive_standings_base_url(str(config.JOLPICA_API_URL))
+            pacer = get_jolpica_pacer(base_url)
             url = f"{base_url}/{year}/driverStandings.json"
             logger.info("Fetching driver standings from %s", url)
-            response = await fetch_with_retry(client, url, logger=logger)
+            response = await fetch_with_retry(client, url, pacer=pacer, logger=logger)
 
             data = response.json()
             standings_list = (
@@ -225,9 +226,10 @@ class StandingsService:
         try:
             client = get_shared_http_client(httpx.AsyncClient, timeout=self.timeout)
             base_url = self._derive_standings_base_url(str(config.JOLPICA_API_URL))
+            pacer = get_jolpica_pacer(base_url)
             url = f"{base_url}/{year}/constructorStandings.json"
             logger.info("Fetching constructor standings from %s", url)
-            response = await fetch_with_retry(client, url, logger=logger)
+            response = await fetch_with_retry(client, url, pacer=pacer, logger=logger)
 
             data = response.json()
             standings_list = (

--- a/app/services/teams_service.py
+++ b/app/services/teams_service.py
@@ -15,8 +15,8 @@ from app.config import config
 from app.models import TeamDriverEntry, TeamEntry, TeamsData
 from app.services.http_client import get_shared_http_client
 from app.utils.f1_season import get_current_f1_season, is_supported_f1_season
-from app.utils.http import fetch_with_retry
-from app.utils.jolpica import get_jolpica_base_url
+from app.utils.http import AsyncPacer, fetch_with_retry
+from app.utils.jolpica import get_jolpica_base_url, get_jolpica_pacer
 from app.utils.standings_metadata import get_season_driver_number_by_id
 
 logger = logging.getLogger(__name__)
@@ -61,12 +61,27 @@ def _extract_standings_rows(payload: dict, rows_name: str) -> list[dict]:
 
 
 async def _fetch_api_standings_rows(
-    client: httpx.AsyncClient, api_base: str, year: int
+    client: httpx.AsyncClient,
+    api_base: str,
+    year: int,
+    *,
+    pacer: AsyncPacer | None = None,
 ) -> tuple[list[dict], list[dict]]:
     """Fetch and extract driver and constructor standings for one season."""
+    pacer = pacer or get_jolpica_pacer(api_base)
     driver_response, constructor_response = await asyncio.gather(
-        fetch_with_retry(client, f"{api_base}/{year}/driverStandings.json", logger=logger),
-        fetch_with_retry(client, f"{api_base}/{year}/constructorStandings.json", logger=logger),
+        fetch_with_retry(
+            client,
+            f"{api_base}/{year}/driverStandings.json",
+            pacer=pacer,
+            logger=logger,
+        ),
+        fetch_with_retry(
+            client,
+            f"{api_base}/{year}/constructorStandings.json",
+            pacer=pacer,
+            logger=logger,
+        ),
     )
     return (
         _extract_standings_rows(driver_response.json(), "DriverStandings"),
@@ -376,14 +391,15 @@ class TeamsService:
         """Fetch driver and constructor standings from API."""
         client = get_shared_http_client(httpx.AsyncClient, timeout=self.timeout)
         api_base = get_jolpica_base_url()
+        pacer = get_jolpica_pacer(api_base)
         driver_standings_url = f"{api_base}/{year}/driverStandings.json"
         constructor_standings_url = f"{api_base}/{year}/constructorStandings.json"
 
         logger.info("Fetching standings for %d", year)
 
         driver_resp, constructor_resp = await asyncio.gather(
-            fetch_with_retry(client, driver_standings_url, logger=logger),
-            fetch_with_retry(client, constructor_standings_url, logger=logger),
+            fetch_with_retry(client, driver_standings_url, pacer=pacer, logger=logger),
+            fetch_with_retry(client, constructor_standings_url, pacer=pacer, logger=logger),
         )
 
         driver_standings: dict[str, dict] = {}
@@ -506,6 +522,7 @@ class TeamsService:
         """Build teams data entirely from Jolpica when no bundled roster exists."""
         client = get_shared_http_client(httpx.AsyncClient, timeout=self.timeout)
         api_base = get_jolpica_base_url()
+        pacer = get_jolpica_pacer(api_base)
         drivers_url = f"{api_base}/{year}/drivers.json?limit=50"
         constructors_url = f"{api_base}/{year}/constructors.json"
         driver_standings_url = f"{api_base}/{year}/driverStandings.json"
@@ -519,10 +536,10 @@ class TeamsService:
             driver_standings_resp,
             constructor_standings_resp,
         ) = await asyncio.gather(
-            fetch_with_retry(client, drivers_url, logger=logger),
-            fetch_with_retry(client, constructors_url, logger=logger),
-            fetch_with_retry(client, driver_standings_url, logger=logger),
-            fetch_with_retry(client, constructor_standings_url, logger=logger),
+            fetch_with_retry(client, drivers_url, pacer=pacer, logger=logger),
+            fetch_with_retry(client, constructors_url, pacer=pacer, logger=logger),
+            fetch_with_retry(client, driver_standings_url, pacer=pacer, logger=logger),
+            fetch_with_retry(client, constructor_standings_url, pacer=pacer, logger=logger),
         )
 
         drivers_data = drivers_resp.json()
@@ -545,7 +562,7 @@ class TeamsService:
             (
                 driver_standings_entries,
                 constructor_standings_entries,
-            ) = await _fetch_api_standings_rows(client, api_base, year - 1)
+            ) = await _fetch_api_standings_rows(client, api_base, year - 1, pacer=pacer)
         driver_to_constructor, drivers_by_id = _build_driver_api_maps(
             driver_standings_entries, drivers_list
         )

--- a/app/utils/http.py
+++ b/app/utils/http.py
@@ -18,24 +18,29 @@ MAX_RETRY_DELAY = 300.0
 
 
 class AsyncPacer:
-    """Keep a minimum gap between outbound requests that share an upstream API."""
+    """Limit sustained request rate while allowing a bounded initial burst."""
 
-    def __init__(self, min_interval: float) -> None:
-        """Initialize a pacer with a strictly positive interval in seconds."""
+    def __init__(self, min_interval: float, *, burst_capacity: int = 1) -> None:
+        """Initialize a pacer with a refill interval and positive burst capacity."""
         if not math.isfinite(min_interval) or min_interval <= 0:
             raise ValueError("min_interval must be finite and positive")
+        if burst_capacity <= 0:
+            raise ValueError("burst_capacity must be positive")
         self._min_interval = min_interval
+        self._burst_window = min_interval * (burst_capacity - 1)
         self._lock = asyncio.Lock()
         self._next_allowed = 0.0
 
     async def wait(self) -> None:
-        """Wait until the next request slot and reserve the following slot."""
+        """Reserve one request token, sleeping only when the burst budget is empty."""
         async with self._lock:
             loop = asyncio.get_running_loop()
-            delay = self._next_allowed - loop.time()
+            now = loop.time()
+            delay = self._next_allowed - self._burst_window - now
             if delay > 0:
                 await asyncio.sleep(delay)
-            self._next_allowed = loop.time() + self._min_interval
+                now = loop.time()
+            self._next_allowed = max(self._next_allowed, now) + self._min_interval
 
 
 def is_transient_http_status(status_code: int) -> bool:

--- a/app/utils/jolpica.py
+++ b/app/utils/jolpica.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
+import weakref
+from urllib.parse import urlsplit
+
 from app.config import config
+from app.utils.http import AsyncPacer
+
+_jolpica_pacers: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, AsyncPacer]] = (
+    weakref.WeakKeyDictionary()
+)
 
 
 def get_jolpica_base_url(api_url: str | None = None) -> str:
@@ -12,3 +21,23 @@ def get_jolpica_base_url(api_url: str | None = None) -> str:
         if normalized.endswith(suffix):
             return normalized[: -len(suffix)].rstrip("/")
     return normalized
+
+
+def get_jolpica_pacer(api_url: str | None = None) -> AsyncPacer:
+    """Return the shared pacing gate for a Jolpica host in the running event loop."""
+    loop = asyncio.get_running_loop()
+    pacers = _jolpica_pacers.setdefault(loop, {})
+    upstream_host = urlsplit(get_jolpica_base_url(api_url)).netloc.casefold()
+    pacer = pacers.get(upstream_host)
+    if pacer is None:
+        pacer = AsyncPacer(
+            config.JOLPICA_MIN_REQUEST_INTERVAL,
+            burst_capacity=config.JOLPICA_BURST_CAPACITY,
+        )
+        pacers[upstream_host] = pacer
+    return pacer
+
+
+def _reset_jolpica_pacers_for_tests() -> None:
+    """Clear shared pacing state between tests that mutate Jolpica configuration."""
+    _jolpica_pacers.clear()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "f1-eink-calendar",
-  "version": "1.2.36",
+  "version": "1.2.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "f1-eink-calendar",
-      "version": "1.2.36",
+      "version": "1.2.37",
       "devDependencies": {
         "@tailwindcss/cli": "^4.3.3",
         "tailwindcss": "^4.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "f1-eink-calendar",
-  "version": "1.2.36",
+  "version": "1.2.37",
   "private": true,
   "scripts": {
     "build:css": "tailwindcss -i ./app/assets/css/input.css -o ./app/assets/css/tailwind.min.css --minify",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "f1-eink-cal"
-version = "1.2.36"
+version = "1.2.37"
 description = "F1 E-Ink calendar service generating 800x480 1-bit BMPs for LaskaKit displays"
 readme = "README.md"
 authors = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,7 +43,9 @@ def test_config_defaults():
     assert config.STATS_RATE_LIMIT_PER_MINUTE == 60
     assert config.STATS_RETENTION_DAYS == 400
     assert config.JOLPICA_MIN_REQUEST_INTERVAL == 2.0
+    assert config.JOLPICA_BURST_CAPACITY == 6
     assert config.JOLPICA_MAX_RETRIES == 6
+    assert config.HISTORICAL_REFRESH_TIMEOUT_SECONDS == 5400
 
 
 def test_default_stats_retention_covers_longest_dashboard_range():
@@ -83,11 +85,13 @@ def test_config_treats_explicitly_empty_admin_token_as_unset():
 def test_shipped_example_env_files_boot(env_file, monkeypatch):
     monkeypatch.delenv("ADMIN_API_TOKEN", raising=False)
     monkeypatch.delenv("STATS_RETENTION_DAYS", raising=False)
+    monkeypatch.delenv("HISTORICAL_REFRESH_TIMEOUT_SECONDS", raising=False)
 
     config = config_module.Config(_env_file=env_file)
 
     assert config.ADMIN_API_TOKEN is None
     assert config.STATS_RETENTION_DAYS == 400
+    assert config.HISTORICAL_REFRESH_TIMEOUT_SECONDS == 5400
 
 
 @pytest.mark.parametrize(
@@ -111,7 +115,9 @@ def test_config_invalid_env_falls_back(monkeypatch):
     monkeypatch.setenv("APP_PORT", "-1")
     monkeypatch.setenv("REQUEST_TIMEOUT", "0")
     monkeypatch.setenv("JOLPICA_MIN_REQUEST_INTERVAL", "0")
+    monkeypatch.setenv("JOLPICA_BURST_CAPACITY", "0")
     monkeypatch.setenv("JOLPICA_MAX_RETRIES", "0")
+    monkeypatch.setenv("HISTORICAL_REFRESH_TIMEOUT_SECONDS", "0")
     monkeypatch.setenv("DEFAULT_TIMEZONE", "Not/AZone")
     monkeypatch.setenv("SITE_URL", "not-a-url")
     monkeypatch.setenv("UMAMI_API_URL", "not-a-url")
@@ -129,7 +135,9 @@ def test_config_invalid_env_falls_back(monkeypatch):
     assert config.APP_PORT == 8000
     assert config.REQUEST_TIMEOUT == 10
     assert config.JOLPICA_MIN_REQUEST_INTERVAL == 2.0
+    assert config.JOLPICA_BURST_CAPACITY == 6
     assert config.JOLPICA_MAX_RETRIES == 6
+    assert config.HISTORICAL_REFRESH_TIMEOUT_SECONDS == 5400
     assert config.DEFAULT_TIMEZONE == "Europe/Prague"
     assert str(config.SITE_URL) == "http://localhost:8000"
     assert str(config.UMAMI_API_URL) == "https://analytics.example.com/api/send"

--- a/tests/test_f1_service.py
+++ b/tests/test_f1_service.py
@@ -346,9 +346,11 @@ def test_next_race_static_uses_last_completed_race_for_empty_offseason(monkeypat
 async def test_get_season_races_uses_configured_api_base_url(monkeypatch):
     service = F1Service()
     service.api_base_url = "https://mirror.example.com/custom/f1"
+    pacer = object()
     mock_fetch = AsyncMock(return_value=MockResponse({"MRData": {"RaceTable": {"Races": []}}}))
 
     monkeypatch.setattr(f1, "fetch_with_retry", mock_fetch)
+    monkeypatch.setattr(f1, "get_jolpica_pacer", lambda api_url: pacer)
     monkeypatch.setattr(
         f1,
         "get_shared_http_client",
@@ -357,11 +359,13 @@ async def test_get_season_races_uses_configured_api_base_url(monkeypatch):
 
     await service.get_season_races(2026)
     assert mock_fetch.await_args.args[1] == "https://mirror.example.com/custom/f1/2026.json"
+    assert mock_fetch.await_args.kwargs["pacer"] is pacer
 
     await service.get_race_by_round(2026, 3)
     assert (
         mock_fetch.await_args_list[1].args[1] == "https://mirror.example.com/custom/f1/2026/3.json"
     )
+    assert mock_fetch.await_args_list[1].kwargs["pacer"] is pacer
 
 
 @pytest.mark.asyncio

--- a/tests/test_f1_service.py
+++ b/tests/test_f1_service.py
@@ -347,10 +347,15 @@ async def test_get_season_races_uses_configured_api_base_url(monkeypatch):
     service = F1Service()
     service.api_base_url = "https://mirror.example.com/custom/f1"
     pacer = object()
+    pacer_urls: list[str] = []
     mock_fetch = AsyncMock(return_value=MockResponse({"MRData": {"RaceTable": {"Races": []}}}))
 
+    def mock_get_jolpica_pacer(api_url: str) -> object:
+        pacer_urls.append(api_url)
+        return pacer
+
     monkeypatch.setattr(f1, "fetch_with_retry", mock_fetch)
-    monkeypatch.setattr(f1, "get_jolpica_pacer", lambda api_url: pacer)
+    monkeypatch.setattr(f1, "get_jolpica_pacer", mock_get_jolpica_pacer)
     monkeypatch.setattr(
         f1,
         "get_shared_http_client",
@@ -366,6 +371,10 @@ async def test_get_season_races_uses_configured_api_base_url(monkeypatch):
         mock_fetch.await_args_list[1].args[1] == "https://mirror.example.com/custom/f1/2026/3.json"
     )
     assert mock_fetch.await_args_list[1].kwargs["pacer"] is pacer
+    assert pacer_urls == [
+        "https://mirror.example.com/custom/f1",
+        "https://mirror.example.com/custom/f1",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_historical_refresh.py
+++ b/tests/test_historical_refresh.py
@@ -1,5 +1,6 @@
 """Extended completeness and persistence coverage for historical refreshes."""
 
+import asyncio
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -239,6 +240,82 @@ async def test_main_does_not_write_when_filtered_result_is_unchanged(tmp_path):
     assert result == historical.HistoricalRefreshResult((), (), 1)
     fetch.assert_awaited_once()
     write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_main_persists_completed_circuits_before_cancellation(tmp_path):
+    path = tmp_path / "circuits.json"
+    circuits = {"monza": {}, "imola": {}}
+    path.write_text(json.dumps(circuits), encoding="utf-8")
+
+    async def fetch(_client, circuit_id, **_kwargs):
+        if circuit_id == "imola":
+            raise asyncio.CancelledError
+        return historical.CircuitFetchOutcome({"season": 2026, "value": "complete"}, True)
+
+    write = MagicMock()
+    with (
+        patch("app.services.historical_refresh.ensure_runtime_circuits_data", return_value=path),
+        patch("app.services.historical_refresh._current_year", return_value=2026),
+        patch("app.services.historical_refresh.get_shared_http_client", return_value=object()),
+        patch("app.services.historical_refresh._fetch_results_with_status", new=fetch),
+        patch("app.services.historical_refresh.atomic_write_json", write),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await historical.main()
+
+    persisted = write.call_args.args[1]
+    assert persisted["monza"]["historical"] == {"season": 2026, "value": "complete"}
+    assert "historical" not in persisted["imola"]
+
+
+@pytest.mark.asyncio
+async def test_main_skips_persistence_when_cancelled_before_any_updates(tmp_path):
+    path = tmp_path / "circuits.json"
+    path.write_text(json.dumps({"monza": {}}), encoding="utf-8")
+
+    async def cancel(*_args, **_kwargs):
+        raise asyncio.CancelledError
+
+    write = MagicMock()
+    with (
+        patch("app.services.historical_refresh.ensure_runtime_circuits_data", return_value=path),
+        patch("app.services.historical_refresh._current_year", return_value=2026),
+        patch("app.services.historical_refresh.get_shared_http_client", return_value=object()),
+        patch("app.services.historical_refresh._fetch_results_with_status", new=cancel),
+        patch("app.services.historical_refresh.atomic_write_json", write),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await historical.main()
+
+    write.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_main_preserves_cancellation_when_partial_persistence_fails(tmp_path, caplog):
+    path = tmp_path / "circuits.json"
+    path.write_text(json.dumps({"monza": {}, "imola": {}}), encoding="utf-8")
+
+    async def fetch(_client, circuit_id, **_kwargs):
+        if circuit_id == "imola":
+            raise asyncio.CancelledError
+        return historical.CircuitFetchOutcome({"season": 2026, "value": "complete"}, True)
+
+    with (
+        patch("app.services.historical_refresh.ensure_runtime_circuits_data", return_value=path),
+        patch("app.services.historical_refresh._current_year", return_value=2026),
+        patch("app.services.historical_refresh.get_shared_http_client", return_value=object()),
+        patch("app.services.historical_refresh._fetch_results_with_status", new=fetch),
+        patch(
+            "app.services.historical_refresh.atomic_write_json",
+            side_effect=OSError("disk full"),
+        ),
+        caplog.at_level("ERROR", logger="app.services.historical_refresh"),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await historical.main()
+
+    assert "Could not persist partial historical results after cancellation" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/test_http_utils.py
+++ b/tests/test_http_utils.py
@@ -1,5 +1,6 @@
 """Tests for shared HTTP retry helpers."""
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -34,9 +35,14 @@ def test_async_pacer_rejects_invalid_interval(min_interval):
         AsyncPacer(min_interval)
 
 
+def test_async_pacer_rejects_nonpositive_burst_capacity():
+    with pytest.raises(ValueError, match="burst_capacity"):
+        AsyncPacer(1.0, burst_capacity=0)
+
+
 @pytest.mark.asyncio
 async def test_async_pacer_waits_for_the_next_request_slot():
-    loop = SimpleNamespace(time=MagicMock(side_effect=[10.0, 10.0, 10.5, 12.0]))
+    loop = SimpleNamespace(time=MagicMock(side_effect=[10.0, 10.5, 12.0]))
     pacer = AsyncPacer(2.0)
 
     with (
@@ -47,6 +53,31 @@ async def test_async_pacer_waits_for_the_next_request_slot():
         await pacer.wait()
 
     sleep.assert_awaited_once_with(1.5)
+
+
+@pytest.mark.asyncio
+async def test_async_pacer_allows_a_burst_then_resumes_sustained_pacing():
+    now = 10.0
+
+    def monotonic_time():
+        return now
+
+    async def advance_time(delay):
+        nonlocal now
+        now += delay
+
+    loop = SimpleNamespace(time=monotonic_time)
+    pacer = AsyncPacer(2.0, burst_capacity=4)
+
+    with (
+        patch("app.utils.http.asyncio.get_running_loop", return_value=loop),
+        patch("app.utils.http.asyncio.sleep", new=AsyncMock(side_effect=advance_time)) as sleep,
+    ):
+        await asyncio.gather(*(pacer.wait() for _ in range(4)))
+        sleep.assert_not_awaited()
+        await pacer.wait()
+
+    sleep.assert_awaited_once_with(2.0)
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -227,7 +227,7 @@ def _single_log_record(caplog, message: str):
 
 
 @pytest.mark.asyncio
-async def test_refresh_historical_results_defers_rendering_to_hourly_job(monkeypatch):
+async def test_refresh_historical_results_defers_rendering_to_hourly_job(monkeypatch, caplog):
     calls = []
     db = _meta_db("4")
 
@@ -237,13 +237,96 @@ async def test_refresh_historical_results_defers_rendering_to_hourly_job(monkeyp
 
     monkeypatch.setattr(scheduler_maintenance, "update_historical_results", fake_update_historical)
     monkeypatch.setattr(scheduler_maintenance, "get_database", lambda: db)
+    monkeypatch.setattr(scheduler_maintenance, "monotonic", MagicMock(side_effect=[10.0, 10.75]))
 
-    await scheduler_maintenance.refresh_historical_results()
+    with caplog.at_level("INFO", logger="app.services.scheduler_maintenance"):
+        await scheduler_maintenance.refresh_historical_results()
 
     assert calls == ["update"]
     writes = _meta_writes(db)
     assert scheduler_maintenance._HISTORICAL_REFRESH_META_KEY in writes
     assert writes[scheduler_maintenance._HISTORICAL_REFRESH_STREAK_META_KEY] == "0"
+    duration = _single_log_record(caplog, "Historical refresh finished in 0.75 seconds")
+    assert duration.duration_seconds == 0.75
+
+
+@pytest.mark.asyncio
+async def test_refresh_historical_results_times_out_as_an_incomplete_run(monkeypatch, caplog):
+    db = _meta_db()
+    cancelled = False
+
+    async def never_finishes():
+        nonlocal cancelled
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled = True
+            raise
+
+    monkeypatch.setattr(scheduler_maintenance, "update_historical_results", never_finishes)
+    monkeypatch.setattr(scheduler_maintenance, "get_database", lambda: db)
+    monkeypatch.setattr(scheduler_maintenance.config, "HISTORICAL_REFRESH_TIMEOUT_SECONDS", 0.001)
+    monkeypatch.setattr(scheduler_maintenance, "monotonic", MagicMock(side_effect=[20.0, 20.5]))
+
+    with caplog.at_level("INFO", logger="app.services.scheduler_maintenance"):
+        await scheduler_maintenance.refresh_historical_results()
+
+    assert cancelled is True
+    writes = _meta_writes(db)
+    assert scheduler_maintenance._HISTORICAL_REFRESH_META_KEY not in writes
+    assert writes[scheduler_maintenance._HISTORICAL_REFRESH_STREAK_META_KEY] == "1"
+    incomplete = _single_log_record(caplog, "Historical refresh incomplete")
+    assert incomplete.failure_reason == "timeout"
+    assert incomplete.timeout_seconds == 0.001
+    assert not any(
+        record.getMessage() == "Historical refresh exceeded its wall-clock budget"
+        for record in caplog.records
+    )
+    duration = _single_log_record(caplog, "Historical refresh finished in 0.50 seconds")
+    assert duration.duration_seconds == 0.5
+
+
+@pytest.mark.asyncio
+async def test_timeout_does_not_double_count_committed_incomplete_run(monkeypatch):
+    persisted = asyncio.Event()
+    release_persistence = asyncio.Event()
+    stored_streak: str | None = None
+    streak_writes = 0
+
+    async def fake_update_historical():
+        return HistoricalRefreshResult((), ("monza",), 1)
+
+    async def get_cache_meta(key):
+        if key == scheduler_maintenance._HISTORICAL_REFRESH_STREAK_META_KEY:
+            return stored_streak
+        return None
+
+    async def set_cache_meta(key, value):
+        nonlocal stored_streak, streak_writes
+        if key != scheduler_maintenance._HISTORICAL_REFRESH_STREAK_META_KEY:
+            return
+        stored_streak = value
+        streak_writes += 1
+        if streak_writes == 1:
+            persisted.set()
+            await release_persistence.wait()
+
+    db = SimpleNamespace(
+        get_cache_meta=AsyncMock(side_effect=get_cache_meta),
+        set_cache_meta=AsyncMock(side_effect=set_cache_meta),
+    )
+    monkeypatch.setattr(scheduler_maintenance, "update_historical_results", fake_update_historical)
+    monkeypatch.setattr(scheduler_maintenance, "get_database", lambda: db)
+    monkeypatch.setattr(scheduler_maintenance.config, "HISTORICAL_REFRESH_TIMEOUT_SECONDS", 0.01)
+
+    refresh_task = asyncio.create_task(scheduler_maintenance.refresh_historical_results())
+    await asyncio.wait_for(persisted.wait(), timeout=1)
+    await asyncio.sleep(0.05)
+    release_persistence.set()
+    await refresh_task
+
+    assert stored_streak == "1"
+    assert streak_writes == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_standings_service.py
+++ b/tests/test_standings_service.py
@@ -231,6 +231,8 @@ async def test_standings_use_configured_jolpica_api_base_url():
         "https://mirror.example.test/ergast/f1/2024/driverStandings.json",
         "https://mirror.example.test/ergast/f1/2024/constructorStandings.json",
     ]
+    pacers = [call.kwargs["pacer"] for call in mock_fetch.await_args_list]
+    assert pacers[0] is pacers[1]
 
 
 @pytest.mark.asyncio

--- a/tests/test_teams_service.py
+++ b/tests/test_teams_service.py
@@ -322,6 +322,8 @@ async def test_fetch_api_standings_rows_fetches_both_tables():
         "https://api.example/2026/driverStandings.json",
         "https://api.example/2026/constructorStandings.json",
     ]
+    pacers = [item.kwargs["pacer"] for item in fetch.await_args_list]
+    assert pacers[0] is pacers[1]
 
 
 def test_api_builders_normalize_driver_constructor_and_standings_data():
@@ -492,6 +494,8 @@ async def test_fetch_standings_normalizes_driver_and_constructor_tables():
         {"Test Driver": {"position": 1, "points": 25.0, "wins": 1}},
         {"Team": {"position": 1, "points": 40.0}},
     )
+    pacers = [item.kwargs["pacer"] for item in fetch.await_args_list]
+    assert pacers[0] is pacers[1]
 
 
 @pytest.mark.asyncio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
 from io import BytesIO
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -12,7 +13,7 @@ from fastapi import Request
 from PIL import Image
 
 from app.services import http_client
-from app.utils import async_tasks, atomic_io, rate_limit
+from app.utils import async_tasks, atomic_io, jolpica, rate_limit
 from app.utils import http as http_utils
 from app.utils.bmp import encode_indexed_bmp_4bit, quantize_to_palette
 from app.utils.f1_season import SEASON_START_DATES, get_current_f1_season
@@ -114,6 +115,44 @@ def test_current_f1_season_before_first_known_start():
     before_first = datetime(earliest.year - 1, 1, 1, tzinfo=timezone.utc)
 
     assert get_current_f1_season(before_first) == min(SEASON_START_DATES) - 1
+
+
+def test_season_start_dates_cover_current_calendar_year():
+    current_year = datetime.now(timezone.utc).year
+
+    assert max(SEASON_START_DATES) >= current_year, (
+        f"SEASON_START_DATES must include the {current_year} first-race date"
+    )
+
+
+@pytest.mark.asyncio
+async def test_jolpica_pacer_is_shared_by_host_within_an_event_loop():
+    jolpica._reset_jolpica_pacers_for_tests()
+    try:
+        first = jolpica.get_jolpica_pacer("https://api.jolpi.ca/ergast/f1/current.json")
+        same_host = jolpica.get_jolpica_pacer(
+            "https://api.jolpi.ca/ergast/f1/2026/driverStandings.json"
+        )
+        other_host = jolpica.get_jolpica_pacer("https://mirror.example/ergast/f1")
+
+        assert first is same_host
+        assert first is not other_host
+    finally:
+        jolpica._reset_jolpica_pacers_for_tests()
+
+
+@pytest.mark.asyncio
+async def test_jolpica_pacer_keeps_full_teams_cache_miss_concurrent():
+    jolpica._reset_jolpica_pacers_for_tests()
+    try:
+        pacer = jolpica.get_jolpica_pacer()
+        with patch("app.utils.http.asyncio.sleep", new=AsyncMock()) as sleep:
+            await asyncio.gather(*(pacer.wait() for _ in range(4)))
+            await asyncio.gather(*(pacer.wait() for _ in range(2)))
+
+        sleep.assert_not_awaited()
+    finally:
+        jolpica._reset_jolpica_pacers_for_tests()
 
 
 def test_retry_after_rejects_invalid_http_date():

--- a/uv.lock
+++ b/uv.lock
@@ -356,7 +356,7 @@ wheels = [
 
 [[package]]
 name = "f1-eink-cal"
-version = "1.2.36"
+version = "1.2.37"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Complete the lower-severity Jolpica reliability follow-ups identified while reviewing #112.

- share one event-loop-safe pacing gate per upstream host across historical, F1 fallback, standings, and teams callers
- route concurrent teams fan-outs through the same gate
- fail the test suite when `SEASON_START_DATES` no longer covers the current UTC year
- bound the nightly historical refresh with a configurable 90-minute timeout
- count timeouts as incomplete runs without advancing freshness and log every run's duration
- publish the patch as version 1.2.37

Closes #111.

Stack status: layer 1 (#112) is merged; this is layer 2 of 2 and now targets `main`.

## Testing

- `uv run --locked pytest tests/ -q -m 'not benchmark' --cov=app --cov-branch --cov-report=term-missing --cov-report=xml` — 1094 passed, 6 deselected
- `uv run --locked diff-cover coverage.xml --compare-branch=origin/main --fail-under=100` — 100%
- `uv run --locked coverage report --fail-under=100` — 100% statement and branch coverage
- `uv run --locked ruff check .`
- `uv run --locked mypy`
- `uv run --locked interrogate -c pyproject.toml app scripts`
- `uv run --locked python -m app.utils.release_validation`
- `uv lock --check`

## Screenshots

Not applicable; rendered output is unchanged.

## Checklist

- [x] I read the Code of Conduct and this change follows it.
- [x] I added or updated documentation as needed.
- [x] I verified timeout, cancellation, failure accounting, and structured logging behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable API request pacing with shared burst allowances.
  * Added a 90-minute limit and runtime tracking for historical refreshes.
  * Added season rollover safeguards.
* **Bug Fixes**
  * Historical refreshes preserve completed updates when cancelled and record timeout details.
* **Documentation**
  * Added configuration guidance and changelog details.
* **Chores**
  * Updated the application version to 1.2.37.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->