### PR TITLE
fix(container): apply runtime security updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,7 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+          no-cache-filters: runtime
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: mode=max

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -51,6 +51,7 @@ jobs:
           context: .
           load: true
           tags: f1-eink-cal:security-scan
+          no-cache-filters: runtime
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.38] - 2026-08-21
+
+### Security
+
+#### Fixed
+
+- **Fresh container security updates** - Upgrade Debian runtime packages during image builds and bypass the runtime-stage cache in security and release workflows so available OS fixes are applied before scanning or publishing
+
 ## [1.2.37] - 2026-08-04
 
 ### Backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ FROM python:3.14-slim@sha256:ce40764625a4ff50df3548277632e7f96c4e77fe75fa848aae9
 WORKDIR /app
 
 # Apply available Debian security updates and install runtime dependencies only.
+# Package versions intentionally follow the current Debian security repository.
+# hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,14 @@ RUN pip install --no-cache-dir --no-deps --prefix=/install --no-warn-script-loca
 # ============================================
 # Stage 2: Runtime
 # ============================================
-FROM python:3.14-slim@sha256:ce40764625a4ff50df3548277632e7f96c4e77fe75fa848aae9885476e7df5a4
+FROM python:3.14-slim@sha256:ce40764625a4ff50df3548277632e7f96c4e77fe75fa848aae9885476e7df5a4 AS runtime
 
 WORKDIR /app
 
-# Install runtime dependencies only (no build tools)
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Apply available Debian security updates and install runtime dependencies only.
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends \
     libjpeg62-turbo \
     zlib1g \
     fonts-symbola \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "f1-eink-cal"
-version = "1.2.37"
+version = "1.2.38"
 description = "F1 E-Ink calendar service generating 800x480 1-bit BMPs for LaskaKit displays"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -356,7 +356,7 @@ wheels = [
 
 [[package]]
 name = "f1-eink-cal"
-version = "1.2.37"
+version = "1.2.38"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Upgrade available Debian packages in the runtime container stage, fixing the current util-linux CVE-2026-53615 findings.
- Name the runtime build stage and bypass its cache in security and release workflows so fresh OS security updates are applied before scanning or publishing.
- Prepare patch release 1.2.38 and update the changelog and lockfile.

## Testing

- uv sync --locked --group dev
- uv run --locked pytest tests/ -q -m "not benchmark" --cov=app --cov-branch --cov-report=term-missing --cov-report=xml (1094 passed, 6 deselected; 100% coverage)
- uv run --locked diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
- uv run --locked ruff check .
- uv run --locked mypy
- interrogate (100%)
- uv run --locked python -m app.utils.release_validation
- actionlint 1.7.7
- docker buildx build --load --no-cache-filter runtime
- Container smoke test
- Trivy 0.70.0 HIGH/CRITICAL image scan (0 findings)

## Screenshots

Not applicable; rendered output is unchanged.

## Checklist

- [x] I read the Code of Conduct and this change follows it.
- [x] I added or updated documentation as needed.
- [x] FastAPI endpoint error handling and logging are unaffected by this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated runtime container packages to include the latest Debian security fixes.
  * Improved release and security builds to ensure runtime image updates are applied reliably.

* **Release**
  * Updated the project version to 1.2.38.
  * Added changelog notes documenting the security improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->